### PR TITLE
Add github mcp queries list with gt label and some comments around it.

### DIFF
--- a/mcp-servers/github/queries_github.json
+++ b/mcp-servers/github/queries_github.json
@@ -1,0 +1,62 @@
+{
+    "meta": {
+        "name": "GitHub",
+        "description": "A collection of queries for GitHub MCP Server.",
+        "note": "Each entry includes a user query and its corresponding tool function name. Useful for LLM tool selection evaluation."
+    },
+    "queries": [
+      {
+        "query": "Search for top 5 Python repositories related to 'llama', sorted by stars.",
+        "tool_call": "search_repositories"
+      },
+      {
+        "query": "Fetch the contents of the readme file from the main branch of the 'llama-stack-on-ocp' repository by 'redhat-et'.",
+        "tool_call": "get_file_contents"
+      },
+      {
+        "query": "List the most recent 3 commits title of the 'llama-stack-on-ocp' repository by 'redhat-et'.",
+        "tool_call": "list_commits"
+      },
+      {
+        "query": "List the current open issues in the 'llama-stack-on-ocp' repository by 'redhat-et'.",
+        "tool_call": "list_issues"
+      },
+      {
+        "query": "Search for issue mentioning 'streamlit app', only list first 3.",
+        "tool_call": "search_issues" 
+      },
+      {
+        "query": "Search for the user 'RHETbot' on GitHub and describe the user.",
+        "tool_call": "search_user"
+      },
+      {
+        "query": "Get the details of issue number 5 in the 'llama-stack-on-ocp' repository by 'redhat-et'.",
+        "tool_call": "get_issue"
+      },
+      {
+        "query": "Get the details of pull request number 18 in the 'llama-stack-on-ocp' repository by 'redhat-et'.",
+        "tool_call": "get_pull_request"
+      },
+      {
+        "query": "List the top 3 most recent pull requests in the 'llama-stack-on-ocp' repository by 'redhat-et'.",
+        "tool_call": "list_pull_requests"
+      },
+      {
+        "query": "Get the files changed in pull request number 20 in the 'llama-stack-on-ocp' repository by 'redhat-et'.",
+        "tool_call": "get_pull_request_files"
+      },
+      {
+        "query": "Get pull request status of pr number 20 in the 'llama-stack-on-ocp' repository by 'redhat-et'.",
+        "tool_call": "get_pull_request_status"
+      },
+      {
+        "query": "Get pull request comments of pr number 18 in the 'llama-stack-on-ocp' repository by 'redhat-et'.",
+        "tool_call": "get_pull_request_commits"
+      },
+      {
+        "query": "Get the reviews of pull request number 20 in the 'llama-stack-on-ocp' repository by 'redhat-et'.",
+        "tool_call": "get_pull_request_reviews"
+      }
+    ]
+  }
+  


### PR DESCRIPTION
## 🧩 PR: Add GitHub MCP Read Tool Queries with Ground Truth Labels

### Summary

This PR adds a list of natural language queries for GitHub MCP (Model Context Protocol) tools, each annotated with its corresponding ground truth tool label. These are intended for evaluating tool-calling models in a GitHub-specific use case.

---

### Changes

- Added 13 labeled natural language queries targeting **read-only** GitHub MCP tools
- Included structured `queries_github.json` for use in evaluation
- Documented tool limitations and known issues

---

### Tool Coverage

- **Total tools in GitHub MCP server:** 27  
  - 🛠️ Write tools: 13  
  - 📖 Read tools: 14  
- ✅ Only **read tools** are used for this test, since the GitHub token is read-only
- ⚠️ Excluded `search_code` due to authentication issues (likely higher permission required)

---

### Observations from Testing

- ✅ **Granite-8B** works well with all 13 read tools when prompted one at a time
- ⚠️ Tool-calling **fails after ~2 turns** if queries are sent continuously in the same session  
  **Workaround:** refresh the agent or reinitialize the agent between prompts
- ❌ **LLaMA 3.2–3B / 70B** can identify the correct tool name but fail to call the tool (invalid input format)
- ❌ **LLaMA 8B** hits context limit issues  
 

### Tool Limitations

| Tool                  | Limitation |
|-----------------------|------------|
| `list_issues`       | Return both issues and pull requests, i think it is because issue and pr are counted continuously. |
| `search_issues`       | Only supports global search, no repo scoping |
| `search_user`         | Only supports global search, no repo scoping |
| `get_issue`           | Only accepts issue numbers, not titles or URLs, also need repo name and owner |
| `get_pull_request`    | Requires repo owner, name, and PR number explicitly |
| _All tools_           | No model currently supports multi-turn clarification of required parameters |
| _All tools_           | Models can’t decompose complex queries into multiple tool calls automatically |

---

### Next Steps

- Test prompt tweaks/system prompts to resolve input format issues on LLaMA models
