### PR TITLE
Add example queries for OpenShift MCP server

### DIFF
--- a/mcp-servers/openshift/queries_openshift.json
+++ b/mcp-servers/openshift/queries_openshift.json
@@ -1,0 +1,30 @@
+{
+    "meta": {
+        "name": "OpenShift",
+        "description": "A collection of queries for OpenShift MCP Server.",
+        "model": "",
+        "note": "Each entry includes a user query and its corresponding tool function name. Useful for LLM tool selection evaluation."
+    },
+    "queries": [
+      {
+        "query": "What pods are running in the llama-serve namespace?",
+        "tool_call": "pods_list_in_namespace"
+      },
+      {
+        "query": "Can you delete the pod example in llama-serve namespace?",
+        "tool_call": "pods_delete"
+      },
+      {
+        "query": "Can you fetch the logs of the pod example in the llama-serve namespace?",
+        "tool_call": "pods_log"
+      },
+      {
+        "query": "Create a pod with the docker.io/hello-world image and expose port 8080 in the llama-serve namespace?",
+        "tool_call": "pods_run"
+      },
+      {
+        "query": "What are the events in llama-serve namespace??",
+        "tool_call": "events_list" 
+      }
+    ]
+  }


### PR DESCRIPTION
This PR adds a JSON file containing a set of example queries for the OpenShift MCP server.

**Model:** `ibm-granite/granite-3.2-8b-instruct` currently seems to be performing the best in identifying and invoking the correct tools.

**Tools Covered**
The following tools were successfully invoked in this set:
- pods_list_in_namespace
- pods_delete
- pods_log
- pods_run
- events_list

**Note:** I had to also set the `sampling_params: {"max_tokens":1024}` when defining the `Agent` config in order to get successful output responses