### PR TITLE
HOLD: add label to NS

### DIFF
--- a/kubernetes/namespace/namespace.yaml
+++ b/kubernetes/namespace/namespace.yaml
@@ -4,3 +4,5 @@ metadata:
   name: llama-serve
   annotations:
     argocd.argoproj.io/sync-wave: "0"
+    labels:
+      modelmesh-enabled: 'false'


### PR DESCRIPTION
Add label to namespace for better RHOAI experience. 

HOLD until I can test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Introduced a new Kubernetes namespace label for llama-serve, standardizing environment metadata and ensuring predictable behavior across deployments. The label is set to a conservative default and does not alter existing annotations or resource identifiers. This change does not affect current user workflows or interfaces but improves operational clarity and enables future configuration adjustments without service disruption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->