### PR TITLE
fix: update DEFAULT_URLS to use llama-stack documentation

### DIFF
--- a/demos/01_foundations/06_search_vectors.py
+++ b/demos/01_foundations/06_search_vectors.py
@@ -39,13 +39,15 @@ try:
 except Exception:  # pragma: no cover - optional dependency
     load_dotenv = None
 
-
+# Note: Using .mdx URLs may produce misleading search scores due to
+# JSX syntax and Docusaurus-specific markup being included in embeddings.
+# For production use, consider using plain .md files instead.
 DEFAULT_URLS = [
-    "https://raw.githubusercontent.com/pytorch/torchtune/main/docs/source/tutorials/memory_optimizations.rst",
-    "https://raw.githubusercontent.com/pytorch/torchtune/main/docs/source/tutorials/chat.rst",
-    "https://raw.githubusercontent.com/pytorch/torchtune/main/docs/source/tutorials/llama3.rst",
-    "https://raw.githubusercontent.com/pytorch/torchtune/main/docs/source/tutorials/qat_finetune.rst",
-    "https://raw.githubusercontent.com/pytorch/torchtune/main/docs/source/tutorials/lora_finetune.rst",
+    "https://raw.githubusercontent.com/llamastack/llama-stack/refs/heads/main/README.md",
+    "https://raw.githubusercontent.com/llamastack/llama-stack/refs/heads/main/docs/docs/index.mdx",
+    "https://raw.githubusercontent.com/llamastack/llama-stack/refs/heads/main/docs/docs/getting_started/quickstart.mdx",
+    "https://raw.githubusercontent.com/llamastack/llama-stack/refs/heads/main/docs/docs/concepts/architecture.mdx",
+    "https://raw.githubusercontent.com/llamastack/llama-stack/refs/heads/main/docs/docs/api-overview.md",
 ]
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Changed vector search example URLs from torchtune docs to llama-stack docs for better relevance to the llama-stack-demos repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched demo vector-search data sources to use llama-stack documentation (README, quickstart, architecture, index/overview) so examples reflect those docs.
  * Added an informational note in the demo warning that embedding scores can be misleading when ingesting MDX/JSX-formatted content and recommending plain Markdown for production ingestion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->