### PR TITLE
fix: Add .env loading to get TAVILY_SEARCH_API_KEY for web searching.

### DIFF
--- a/demos/01_foundations/07_tool_registration.py
+++ b/demos/01_foundations/07_tool_registration.py
@@ -27,7 +27,7 @@ from llama_stack_client import LlamaStackClient
 
 try:
     from dotenv import load_dotenv
-except Exception:  # pragma: no cover - optional dependency
+except ImportError:  # pragma: no cover - optional dependency
     load_dotenv = None
 
 

--- a/demos/01_foundations/08_mcp_tools.py
+++ b/demos/01_foundations/08_mcp_tools.py
@@ -26,7 +26,7 @@ from llama_stack_client import LlamaStackClient
 
 try:
     from dotenv import load_dotenv
-except Exception:  # pragma: no cover - optional dependency
+except ImportError:  # pragma: no cover - optional dependency
     load_dotenv = None
 
 
@@ -41,7 +41,7 @@ def serve() -> None:
     """
     try:
         from mcp.server.fastmcp import FastMCP
-    except Exception:  # pragma: no cover - optional dependency
+    except ImportError:  # pragma: no cover - optional dependency
         print(
             colored(
                 "Missing dependency 'mcp'. Install with: pip install mcp",

--- a/demos/04_agents/01_simple_agent_chat.py
+++ b/demos/04_agents/01_simple_agent_chat.py
@@ -28,7 +28,7 @@ from demos.shared.utils import check_model_is_available, get_any_available_chat_
 
 try:
     from dotenv import load_dotenv
-except Exception:  # pragma: no cover - optional dependency
+except ImportError:  # pragma: no cover - optional dependency
     load_dotenv = None
 
 

--- a/demos/04_agents/01_simple_agent_chat.py
+++ b/demos/04_agents/01_simple_agent_chat.py
@@ -26,8 +26,19 @@ from termcolor import colored
 
 from demos.shared.utils import check_model_is_available, get_any_available_chat_model
 
+try:
+    from dotenv import load_dotenv
+except Exception:  # pragma: no cover - optional dependency
+    load_dotenv = None
+
+
+def _maybe_load_dotenv() -> None:
+    if load_dotenv is not None:
+        load_dotenv()
+
 
 def main(host: str, port: int, model_id: str | None = None):
+    _maybe_load_dotenv()
     if "TAVILY_SEARCH_API_KEY" not in os.environ:
         print(
             colored(

--- a/demos/04_agents/04_agent_with_tools.py
+++ b/demos/04_agents/04_agent_with_tools.py
@@ -29,8 +29,19 @@ from llama_stack_client import LlamaStackClient, Agent, AgentEventLogger
 
 from demos.shared.utils import can_model_chat, check_model_is_available, get_any_available_chat_model
 
+try:
+    from dotenv import load_dotenv
+except Exception:  # pragma: no cover - optional dependency
+    load_dotenv = None
+
+
+def _maybe_load_dotenv() -> None:
+    if load_dotenv is not None:
+        load_dotenv()
+
 
 def main(host: str, port: int, model_id: str | None = None):
+    _maybe_load_dotenv()
     client = LlamaStackClient(base_url=f"http://{host}:{port}")
 
     api_key = ""

--- a/demos/04_agents/04_agent_with_tools.py
+++ b/demos/04_agents/04_agent_with_tools.py
@@ -31,7 +31,7 @@ from demos.shared.utils import can_model_chat, check_model_is_available, get_any
 
 try:
     from dotenv import load_dotenv
-except Exception:  # pragma: no cover - optional dependency
+except ImportError:  # pragma: no cover - optional dependency
     load_dotenv = None
 
 

--- a/demos/04_agents/06_react_agent.py
+++ b/demos/04_agents/06_react_agent.py
@@ -27,6 +27,16 @@ from termcolor import colored
 
 from demos.shared.utils import can_model_chat, check_model_is_available, get_any_available_chat_model
 
+try:
+    from dotenv import load_dotenv
+except Exception:  # pragma: no cover - optional dependency
+    load_dotenv = None
+
+
+def _maybe_load_dotenv() -> None:
+    if load_dotenv is not None:
+        load_dotenv()
+
 
 def torchtune(query: str = "torchtune"):  # noqa: ARG001
     """
@@ -53,6 +63,8 @@ def torchtune(query: str = "torchtune"):  # noqa: ARG001
 
 
 def main(host: str, port: int, model_id: str | None = None):
+    _maybe_load_dotenv()
+
     tavily_api_key = os.getenv("TAVILY_SEARCH_API_KEY")
     if not tavily_api_key:
         print(

--- a/demos/04_agents/06_react_agent.py
+++ b/demos/04_agents/06_react_agent.py
@@ -29,7 +29,7 @@ from demos.shared.utils import can_model_chat, check_model_is_available, get_any
 
 try:
     from dotenv import load_dotenv
-except Exception:  # pragma: no cover - optional dependency
+except ImportError:  # pragma: no cover - optional dependency
     load_dotenv = None
 
 

--- a/demos/04_agents/07_agent_routing.py
+++ b/demos/04_agents/07_agent_routing.py
@@ -30,6 +30,16 @@ from llama_stack_client import Agent, LlamaStackClient
 
 from demos.shared.utils import can_model_chat, check_model_is_available, get_any_available_chat_model
 
+try:
+    from dotenv import load_dotenv
+except Exception:  # pragma: no cover - optional dependency
+    load_dotenv = None
+
+
+def _maybe_load_dotenv() -> None:
+    if load_dotenv is not None:
+        load_dotenv()
+
 
 def _resolve_web_tool():
     api_key = ""
@@ -87,6 +97,8 @@ def _extract_output(response) -> str:
 
 
 def main(host: str, port: int, model_id: str | None = None):
+    _maybe_load_dotenv()
+
     client = LlamaStackClient(base_url=f"http://{host}:{port}")
 
     if model_id is None:

--- a/demos/04_agents/07_agent_routing.py
+++ b/demos/04_agents/07_agent_routing.py
@@ -32,7 +32,7 @@ from demos.shared.utils import can_model_chat, check_model_is_available, get_any
 
 try:
     from dotenv import load_dotenv
-except Exception:  # pragma: no cover - optional dependency
+except ImportError:  # pragma: no cover - optional dependency
     load_dotenv = None
 
 


### PR DESCRIPTION
Add `.env` loading to agent demos for environment variables.

## Description
Added dotenv loading functionality to 4 **agent demos**:
- `01_simple_agent_chat.py`
- `04_agent_with_tools.py`
- `06_react_agent.py`
- `07_agent_routing.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Demo apps now optionally load environment variables from dotenv files when available, so environment setup is handled automatically at startup.
  * Improved handling of missing optional dependencies for more graceful, reliable behavior while preserving existing workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->