### PR TITLE
Update OpenAI demo prompts to use open-source questions

### DIFF
--- a/demos/06_openai_compatibility/01_chat_completion.py
+++ b/demos/06_openai_compatibility/01_chat_completion.py
@@ -53,7 +53,7 @@ def main(
     host: str,
     port: int,
     model_id: str | None = None,
-    prompt: str = "Give me a short summary of Llama Stack.",
+    prompt: str = "What are the benefits of open-source software?",
     stream: bool = False,
     scheme: str = "http",
 ) -> None:

--- a/demos/06_openai_compatibility/03_responses_api.py
+++ b/demos/06_openai_compatibility/03_responses_api.py
@@ -67,7 +67,7 @@ def main(
     print(colored("\n--- String input ---", "cyan"))
     response = client.responses.create(
         model=resolved_model,
-        input="Give a one-sentence description of Llama Stack.",
+        input="What is open-source software in one sentence?",
     )
     print(response.output_text)
 
@@ -78,7 +78,7 @@ def main(
         input=[
             {
                 "role": "user",
-                "content": "List three benefits of running open-source LLMs locally.",
+                "content": "What is open-source software in one sentence?",
             },
         ],
     )


### PR DESCRIPTION
## Description
The suggested models were trained on data with a cutoff date. Without a knowledge base, they cannot answer questions like "What is llama stack?", and will only respond with "I don't have information on "Llama Stack." Could you provide more context or clarify what you're referring to? I'd be happy to try and help!". 

This makes the demo seem as though the API isn't working successfully.

So I replace Llama Stack questions with open-source software questions that the model can answer, keeping focus on OpenAI API compatibility.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated prompts in OpenAI compatibility demonstration examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->