### PR TITLE
Add demos/00_setup with provider configuration guide

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,27 +1,58 @@
-# mandatory unless a local deployment is used
-REMOTE_BASE_URL= "http://llamastack-server:8321"
+# =============================================================================
+# Inference Providers (set API keys to enable; OGX auto-detects on startup)
+# =============================================================================
+OLLAMA_URL="http://localhost:11434/v1"
+# OPENAI_API_KEY=""
+# ANTHROPIC_API_KEY=""
+# GEMINI_API_KEY=""
+# VLLM_URL="http://localhost:8000/v1"
 
-# optional environment variables for all demos
-TEMPERATURE="0.0"
-TOP_P="0.95"
-MAX_TOKENS="512"
-STREAM="False"
+# =============================================================================
+# OGX server connection
+# =============================================================================
+REMOTE_BASE_URL="http://localhost:8321"
+# OGX_API_KEY=""                    # for OpenAI-compatible demos (use 'fake' for local server)
 
-# for the RAG demos only - mandatory
-VDB_PROVIDER="milvus"
-VDB_EMBEDDING="all-MiniLM-L6-v2"
+# =============================================================================
+# Model selection (leave commented to auto-select from available models)
+# =============================================================================
+# OGX_CHAT_MODEL=""                 # e.g. "openai/gpt-4o-mini", "ollama/llama3.2:3b"
+# OGX_EMBEDDING_MODEL=""            # e.g. "openai/text-embedding-3-small"
 
-# for the RAG demos only - optional
-VDB_EMBEDDING_DIMENSION="384"
-VECTOR_DB_CHUNK_SIZE="512"
+# =============================================================================
+# Search API keys (agent demos)
+# =============================================================================
+# TAVILY_SEARCH_API_KEY=""
+# BRAVE_SEARCH_API_KEY=""
 
-# for the agentic/tool demos
-TAVILY_SEARCH_API_KEY= ""
-USE_PROMPT_CHAINING= "True"
+# =============================================================================
+# Inference parameters (optional)
+# =============================================================================
+# TEMPERATURE="0.0"
+# TOP_P="0.95"
+# MAX_TOKENS="512"
+# STREAM="False"
 
-# for the eval notebook only - mandatory
-LLM_AS_JUDGE_MODEL_ID= ""
+# =============================================================================
+# RAG demos (optional)
+# =============================================================================
+# VDB_PROVIDER="milvus"
+# VDB_EMBEDDING="all-MiniLM-L6-v2"
+# VDB_EMBEDDING_DIMENSION="384"
+# VECTOR_DB_CHUNK_SIZE="512"
 
-# MCP-related
-REMOTE_OCP_MCP_URL= "http://ocp-mcp-server:8000/sse"
-REMOTE_SLACK_MCP_URL= "http://slack-mcp-server:80/sse"
+# =============================================================================
+# Agent demos (optional)
+# =============================================================================
+# USE_PROMPT_CHAINING="True"
+
+# =============================================================================
+# Eval notebook (optional)
+# =============================================================================
+# LLM_AS_JUDGE_MODEL_ID=""
+
+# =============================================================================
+# MCP servers (optional, for Kubernetes deployment)
+# =============================================================================
+# REMOTE_OCP_MCP_URL="http://ocp-mcp-server:8000/sse"
+# REMOTE_SLACK_MCP_URL="http://slack-mcp-server:80/sse"

--- a/demos/00_setup/01_list_providers.py
+++ b/demos/00_setup/01_list_providers.py
@@ -1,0 +1,100 @@
+"""
+Demo: List Providers and Models
+
+Description:
+This demo shows how to inspect the providers and models available on your OGX server.
+Use it to verify your server is configured correctly before running other demos.
+
+Learning Objectives:
+- List all configured inference providers
+- List all available models and their types (LLM, embedding, rerank)
+- Understand how providers map to models
+"""
+
+from __future__ import annotations
+
+import fire
+from ogx_client import OgxClient
+from termcolor import colored
+
+try:
+    from dotenv import load_dotenv
+except Exception:
+    load_dotenv = None
+
+
+def main(host: str = "localhost", port: int = 8321) -> None:
+    if load_dotenv is not None:
+        load_dotenv()
+
+    client = OgxClient(base_url=f"http://{host}:{port}")
+
+    try:
+        client.inspect.health()
+    except Exception as exc:
+        print(colored(f"Cannot connect to OGX server at {host}:{port}: {exc}", "red"))
+        return
+
+    print("=== Providers ===")
+    providers = client.providers.list()
+    inference_providers = [p for p in providers if p.api == "inference"]
+    vector_providers = [p for p in providers if p.api == "vector_io"]
+    other_providers = [p for p in providers if p.api not in ("inference", "vector_io")]
+
+    if inference_providers:
+        print("\nInference:")
+        for p in inference_providers:
+            print(f"  - {p.provider_id} ({p.provider_type})")
+    if vector_providers:
+        print("\nVector I/O:")
+        for p in vector_providers:
+            print(f"  - {p.provider_id} ({p.provider_type})")
+    if other_providers:
+        print("\nOther:")
+        for p in other_providers:
+            print(f"  - {p.provider_id} ({p.provider_type}) [{p.api}]")
+
+    print("\n=== Models ===")
+    resp = client.models.list()
+    models = resp.data if hasattr(resp, "data") else list(resp)
+
+    llm_models = []
+    embedding_models = []
+    other_models = []
+
+    for m in models:
+        model_id = getattr(m, "identifier", None) or getattr(m, "id", None) or "unknown"
+        meta = getattr(m, "custom_metadata", None) or {}
+        model_type = meta.get("model_type", "unknown") if isinstance(meta, dict) else "unknown"
+        provider = meta.get("provider_id", "?") if isinstance(meta, dict) else "?"
+
+        entry = f"  - {model_id}  (provider: {provider})"
+        if model_type == "llm":
+            llm_models.append(entry)
+        elif model_type == "embedding":
+            embedding_models.append(entry)
+        else:
+            other_models.append(entry)
+
+    if llm_models:
+        print(f"\nLLM ({len(llm_models)}):")
+        for e in llm_models:
+            print(e)
+    if embedding_models:
+        print(f"\nEmbedding ({len(embedding_models)}):")
+        for e in embedding_models:
+            print(e)
+    if other_models:
+        print(f"\nOther ({len(other_models)}):")
+        for e in other_models:
+            print(e)
+
+    if not models:
+        print(colored("  No models available.", "red"))
+
+    total = len(llm_models) + len(embedding_models) + len(other_models)
+    print(f"\nTotal: {total} models across {len(providers)} providers")
+
+
+if __name__ == "__main__":
+    fire.Fire(main)

--- a/demos/00_setup/README.md
+++ b/demos/00_setup/README.md
@@ -1,0 +1,66 @@
+# 00 Setup: Server and Provider Configuration
+
+Before running demos, you need an OGX server with at least one inference provider configured. OGX auto-detects providers based on environment variables.
+
+## Quick Start (Ollama only)
+
+```bash
+ollama pull llama3.2:3b
+OLLAMA_URL=http://localhost:11434/v1 uv run ogx run starter
+```
+
+## Adding Providers
+
+OGX auto-detects providers when their API key is set in the environment. Set the keys in `.env` before starting the server:
+
+| Provider | Environment Variable | Notes |
+|----------|---------------------|-------|
+| Ollama | `OLLAMA_URL` | Default: `http://localhost:11434/v1` |
+| OpenAI | `OPENAI_API_KEY` | GPT-4o, GPT-4o-mini, etc. |
+| Anthropic | `ANTHROPIC_API_KEY` | Claude models |
+| Google Gemini | `GEMINI_API_KEY` | Gemini models |
+| vLLM | `VLLM_URL` | Default: `http://localhost:8000/v1` |
+| Together | `TOGETHER_API_KEY` | |
+| Fireworks | `FIREWORKS_API_KEY` | |
+| AWS Bedrock | `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` | |
+| Azure OpenAI | `AZURE_API_KEY` + `AZURE_API_BASE` | |
+
+### Example: Ollama + OpenAI
+
+```bash
+# In .env:
+OLLAMA_URL=http://localhost:11434/v1
+OPENAI_API_KEY=sk-...
+
+# Start server (auto-detects both providers):
+source .env
+uv run ogx run starter
+```
+
+The server will show detected providers on startup:
+
+```
+Scanning for available providers...
+  ✓ remote::ollama ... (2 models)
+  ✓ remote::openai ... (10 models)
+```
+
+## Verify Your Setup
+
+```bash
+python -m demos.00_setup.01_list_providers localhost 8321
+```
+
+This lists all configured providers and available models.
+
+## Which Provider Do I Need?
+
+| Demo category | Minimum | Recommended |
+|--------------|---------|-------------|
+| 01 Foundations | Any LLM + embedding model | Ollama |
+| 02 Responses | Any LLM | Ollama |
+| 03 RAG | Any LLM + embedding model | Ollama |
+| 04 Agents | Fast LLM with tool calling | OpenAI (gpt-4o-mini) |
+| 06 OpenAI Compatibility | Any LLM | Ollama |
+
+Agent demos (04) involve multi-turn tool calling and work best with faster cloud models. Local models via Ollama may time out on complex agent tasks.

--- a/demos/README.md
+++ b/demos/README.md
@@ -32,68 +32,88 @@ uv venv --python 3.12 --seed
 #    - Sets VIRTUAL_ENV for the current shell session
 source .venv/bin/activate
 
-# 3️⃣ Install ogx with the "starter" extras and the client SDK
-#    - ogx[starter] includes the core CLI plus all provider dependencies
-#      (ollama, chromadb, faiss, etc.) needed by the starter distribution
-#    - ogx-client is the Python SDK for interacting with an OGX server
-uv pip install -U 'ogx[starter]' ogx-client
+# 3️⃣ Configure environment variables
+#    - Copy the example env file to create your local config
+cp .env.example .env
+#    - Edit .env to configure your inference provider(s) and API keys.
+#      Uncomment and fill in the providers you want to use:
+#
+#      Ollama (local, free):
+#        OLLAMA_URL="http://localhost:11434/v1"
+#
+#      OpenAI (cloud, recommended for agent demos):
+#        OPENAI_API_KEY="sk-..."
+#
+#      You can enable multiple providers at once — OGX auto-detects them.
+#      See demos/00_setup/README.md for the full list of supported providers.
+#
+#    - For agent demos (04_agents), also set a search API key:
+#        TAVILY_SEARCH_API_KEY="tvly-..."
 
-# 4️⃣ Run the "starter" OGX server
-#    - This starts a LOCAL server on port 8321 (default for starter distribution)
-#    - The server connects to Ollama at localhost:11434 for inference
+# 4️⃣ Install all dependencies
+#    - This installs ogx with starter extras (provider dependencies like
+#      ollama, chromadb, faiss, sentence-transformers, etc.) and ogx-client
+uv sync
+
+# 5️⃣ Start the OGX server
+#    - Load .env so the server can detect your configured providers
+#    - The server auto-detects providers based on which API keys are set
+#    - It starts on port 8321 by default
 #    - IMPORTANT: Keep this terminal open - the server runs in foreground
-#    - The server must stay running for demos to work
-OLLAMA_URL=http://localhost:11434/v1 uv run ogx run starter
+set -a; source .env; set +a
+uv run ogx run starter
 
-# 5️⃣ Verify the server is running (in a NEW terminal - server must be running!)
+# 6️⃣ Verify the server is running (in a NEW terminal - server must be running!)
 #    - Open a SECOND terminal window
 #    - Navigate to the repository directory and activate the virtual environment
 cd <repo-root>  # Navigate to where you cloned the repo
 source .venv/bin/activate
 
-# 6️⃣ Test the connection
+# 7️⃣ Test the connection
 #    - Run the client setup demo to verify server is running
 python -m demos.01_foundations.01_client_setup localhost 8321  # Note: port 8321 for local starter server
 ```
 
 ### Troubleshooting
 
+**No inference providers detected:**
+```bash
+# Make sure your .env has at least one provider configured and exported
+set -a; source .env; set +a
+# Verify the key is in the environment
+echo $OPENAI_API_KEY   # or $OLLAMA_URL, etc.
+```
+
 **Port already in use (8321):**
 ```bash
-# Find and kill the process using port 8321
 lsof -i :8321
 kill <PID>
 ```
 
-**Server not starting:**
+**Check which providers and models are available:**
 ```bash
-# Check if Ollama is running
-curl http://localhost:11434/api/tags
-
-# Check if a model is pulled
-ollama list
-```
-
-**Version compatibility errors:**
-```bash
-# Reinstall all packages with matching versions
-pip uninstall -y ogx ogx-api ogx-client
-uv pip install -U ogx ogx-client
+python -m demos.00_setup.01_list_providers localhost 8321
 ```
 
 ## Available Demos
 
-### 01_foundations
-Foundation examples demonstrating core OGX concepts and basic usage patterns.
+### 00_setup
+Server setup and provider configuration. Verify your OGX server is running and inspect available providers and models.
 
-### 02_responses_basic
-Basic examples showing how to work with responses in OGX.
+### 01_foundations
+Foundation examples demonstrating core OGX concepts: client setup, chat completions, vector DBs, tool registration, and MCP.
+
+### 02_responses_basics
+Higher-level response generation with tools, structured outputs, streaming, and multi-turn conversations.
 
 ### 03_rag
 RAG (Retrieval-Augmented Generation) examples showing how to ground model responses in retrieved documents using OGX's vector stores and search capabilities.
 
 ### 04_agents
-Agent examples demonstrating how to build conversational agents with various capabilities including chat, multimodal processing, document grounding, custom tools, and multi-agent coordination.
+Agent examples demonstrating conversational agents with chat, tools, RAG, ReAct, and multi-agent routing.
+
+### 05_observability
+OpenTelemetry, Jaeger, Prometheus, and Grafana integration for monitoring OGX servers. *(Requires Docker for the telemetry stack.)*
 
 ### 06_openai_compatibility
 Demos showing that existing OpenAI Python SDK code works against an OGX server with only a `base_url` change, covering chat completions, tool calling, and the Responses API.


### PR DESCRIPTION
## Summary
- Add `demos/00_setup/01_list_providers.py` to inspect server providers and models
- Add `demos/00_setup/README.md` with provider setup instructions
- Update `demos/README.md` with revised setup steps, troubleshooting, and demo descriptions
- Restructure `.env.example` with organized provider config sections

Split from #352 (4/5). Independent.

## Test plan
- [ ] `python -m demos.00_setup.01_list_providers localhost 8321` shows providers and models
- [ ] README instructions are accurate for fresh setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)