### PR TITLE
Add ruff linting, formatting, and demo structure validation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,3 +7,25 @@ repos:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
     -   id: check-added-large-files
+        args: ['--maxkb=500']
+    -   id: check-yaml
+        exclude: ^demos/rag_eval/
+    -   id: check-json
+    -   id: check-merge-conflict
+    -   id: debug-statements
+
+-   repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.18
+    hooks:
+    -   id: ruff
+        args: [--fix]
+    -   id: ruff-format
+
+-   repo: local
+    hooks:
+    -   id: validate-demo-structure
+        name: Validate demo structure
+        entry: python scripts/validate_demos.py
+        language: python
+        files: ^demos/\d{2}_[^/]+/\d{2}_[a-z].*\.py$
+        pass_filenames: true

--- a/demos/01_foundations/04_vector_db_basics.py
+++ b/demos/01_foundations/04_vector_db_basics.py
@@ -20,7 +20,6 @@ Learning Objectives:
 from __future__ import annotations
 
 from io import BytesIO
-import os
 from uuid import uuid4
 
 import fire
@@ -28,8 +27,8 @@ from ogx_client import OgxClient
 from termcolor import colored
 
 from demos.shared.utils import (
-    resolve_embedding_model,
     get_embedding_dimension,
+    resolve_embedding_model,
 )
 
 try:
@@ -44,9 +43,7 @@ def _maybe_load_dotenv() -> None:
 
 
 def _get_vector_provider(client: OgxClient, provider_id: str | None):
-    vector_providers = [
-        provider for provider in client.providers.list() if provider.api == "vector_io"
-    ]
+    vector_providers = [provider for provider in client.providers.list() if provider.api == "vector_io"]
     if not vector_providers:
         print(colored("No available vector_io providers. Exiting.", "red"))
         return None

--- a/demos/01_foundations/05_insert_documents.py
+++ b/demos/01_foundations/05_insert_documents.py
@@ -30,8 +30,8 @@ from termcolor import colored
 
 from demos.shared.utils import (
     download_documents,
-    resolve_embedding_model,
     get_embedding_dimension,
+    resolve_embedding_model,
 )
 
 try:
@@ -55,9 +55,7 @@ def _maybe_load_dotenv() -> None:
 
 
 def _get_vector_provider(client: OgxClient, provider_id: str | None):
-    vector_providers = [
-        provider for provider in client.providers.list() if provider.api == "vector_io"
-    ]
+    vector_providers = [provider for provider in client.providers.list() if provider.api == "vector_io"]
     if not vector_providers:
         print(colored("No available vector_io providers. Exiting.", "red"))
         return None

--- a/demos/01_foundations/06_search_vectors.py
+++ b/demos/01_foundations/06_search_vectors.py
@@ -30,8 +30,8 @@ from termcolor import colored
 
 from demos.shared.utils import (
     download_documents,
-    resolve_embedding_model,
     get_embedding_dimension,
+    resolve_embedding_model,
 )
 
 try:
@@ -72,9 +72,7 @@ def _print_results(search_response) -> None:
 
 
 def _get_vector_provider(client: OgxClient, provider_id: str | None):
-    vector_providers = [
-        provider for provider in client.providers.list() if provider.api == "vector_io"
-    ]
+    vector_providers = [provider for provider in client.providers.list() if provider.api == "vector_io"]
     if not vector_providers:
         print(colored("No available vector_io providers. Exiting.", "red"))
         return None

--- a/demos/01_foundations/07_tool_registration.py
+++ b/demos/01_foundations/07_tool_registration.py
@@ -21,9 +21,8 @@ Learning Objectives:
 from __future__ import annotations
 
 import fire
-from termcolor import colored
-
 from ogx_client import OgxClient
+from termcolor import colored
 
 try:
     from dotenv import load_dotenv
@@ -84,7 +83,7 @@ def main(
         print(f"\nTools available via tool_runtime ({len(tools)}):")
         for tool in tools:
             print(f"  - {tool.name}: {tool.description or 'No description'}")
-            if hasattr(tool, 'parameters') and tool.parameters:
+            if hasattr(tool, "parameters") and tool.parameters:
                 print(f"    Parameters: {tool.parameters}")
     except Exception as exc:
         print(colored(f"Failed to list tools via tool_runtime: {exc}", "yellow"))
@@ -116,7 +115,7 @@ def main(
                         tool_name=tool.name,
                         kwargs=test_kwargs,
                     )
-                    print(colored(f"  ✓ Success! Result:", "green"))
+                    print(colored("  ✓ Success! Result:", "green"))
                     # Pretty print result (truncate if too long)
                     result_str = str(result)
                     if len(result_str) > 500:
@@ -129,37 +128,25 @@ def main(
                     print(colored(f"  ✗ Failed to invoke {tool.name}: {exc}", "yellow"))
 
         if not tool_invoked:
-            print(colored(
-                "\nNo invokable tools found or all invocations failed.",
-                "yellow"
-            ))
-            print(colored(
-                "To see tool invocation in action, you can:",
-                "yellow"
-            ))
-            print(colored(
-                "  1. Configure your OGX server with built-in tools (e.g., code_interpreter, web_search)",
-                "yellow"
-            ))
-            print(colored(
-                "  2. Or see demo 08_mcp_tools.py for MCP-based tool registration and invocation",
-                "yellow"
-            ))
+            print(colored("\nNo invokable tools found or all invocations failed.", "yellow"))
+            print(colored("To see tool invocation in action, you can:", "yellow"))
+            print(
+                colored(
+                    "  1. Configure your OGX server with built-in tools (e.g., code_interpreter, web_search)", "yellow"
+                )
+            )
+            print(colored("  2. Or see demo 08_mcp_tools.py for MCP-based tool registration and invocation", "yellow"))
     else:
         print(colored("No tools available to invoke.", "yellow"))
-        print(colored(
-            "\nNote: This demo shows the tool runtime API structure.",
-            "yellow"
-        ))
-        print(colored(
-            "For a working example with actual tool invocation, see demo 08_mcp_tools.py",
-            "yellow"
-        ))
+        print(colored("\nNote: This demo shows the tool runtime API structure.", "yellow"))
+        print(colored("For a working example with actual tool invocation, see demo 08_mcp_tools.py", "yellow"))
 
     print(colored("\n=== Step 5: Register a Toolgroup (Example) ===", "green"))
     print("To register a toolgroup, you typically need a provider.")
     print("Example with inline provider:")
-    print(colored("""
+    print(
+        colored(
+            """
     # For built-in tools (requires appropriate provider):
     client.toolgroups.register(
         toolgroup_id="my-custom-tools",
@@ -170,7 +157,10 @@ def main(
     # For more advanced examples, see:
     # - demo 08_mcp_tools.py for MCP-based registration
     # - Your OGX server configuration for available providers
-    """, "cyan"))
+    """,
+            "cyan",
+        )
+    )
 
     print(colored("\n=== Summary ===", "green"))
     print("Key APIs demonstrated:")

--- a/demos/01_foundations/08_mcp_tools.py
+++ b/demos/01_foundations/08_mcp_tools.py
@@ -20,9 +20,8 @@ Learning Objectives:
 from __future__ import annotations
 
 import fire
-from termcolor import colored
-
 from ogx_client import OgxClient
+from termcolor import colored
 
 try:
     from dotenv import load_dotenv

--- a/demos/02_responses_basics/02_tool_calling.py
+++ b/demos/02_responses_basics/02_tool_calling.py
@@ -51,10 +51,7 @@ def main(
     host: str,
     port: int,
     model_id: str | None = None,
-    prompt: str = (
-        "Search the web for who was the 42nd president of the United States "
-        "and answer with the name only."
-    ),
+    prompt: str = ("Search the web for who was the 42nd president of the United States and answer with the name only."),
 ) -> None:
     _maybe_load_dotenv()
 

--- a/demos/02_responses_basics/03_conversation_turns.py
+++ b/demos/02_responses_basics/03_conversation_turns.py
@@ -51,9 +51,7 @@ def main(
     host: str,
     port: int,
     model_id: str | None = None,
-    instructions: str = (
-        "You are a helpful assistant. Answer directly and avoid refusing unless safety requires it."
-    ),
+    instructions: str = ("You are a helpful assistant. Answer directly and avoid refusing unless safety requires it."),
 ) -> None:
     _maybe_load_dotenv()
 
@@ -76,8 +74,7 @@ def main(
     print(f"Created conversation={conversation_id}")
 
     prompts = [
-        "We are discussing OGX, a framework and server for running AI models and tools. "
-        "In one sentence, describe it.",
+        "We are discussing OGX, a framework and server for running AI models and tools. In one sentence, describe it.",
         "Summarize the description in three short bullet points.",
         "Give one concrete use case in a single sentence.",
     ]

--- a/demos/02_responses_basics/04_streaming_responses.py
+++ b/demos/02_responses_basics/04_streaming_responses.py
@@ -67,9 +67,7 @@ def main(
     host: str,
     port: int,
     model_id: str | None = None,
-    instructions: str = (
-        "You are a helpful assistant. Answer directly and avoid refusing unless safety requires it."
-    ),
+    instructions: str = ("You are a helpful assistant. Answer directly and avoid refusing unless safety requires it."),
 ) -> None:
     _maybe_load_dotenv()
 
@@ -93,8 +91,7 @@ def main(
     print(f"Created conversation={conversation_id}")
 
     prompts = [
-        "We are discussing OGX, a framework and server for running AI models and tools. "
-        "In one sentence, describe it.",
+        "We are discussing OGX, a framework and server for running AI models and tools. In one sentence, describe it.",
         "Summarize the description in three short bullet points.",
         "Give one concrete use case in a single sentence.",
     ]

--- a/demos/03_rag/01_simple_rag.py
+++ b/demos/03_rag/01_simple_rag.py
@@ -19,8 +19,8 @@ Learning Objectives:
 
 from __future__ import annotations
 
-from io import BytesIO
 import os
+from io import BytesIO
 from uuid import uuid4
 
 import fire
@@ -31,8 +31,8 @@ from demos.shared.utils import (
     can_model_chat,
     check_model_is_available,
     get_any_available_chat_model,
-    resolve_embedding_model,
     get_embedding_dimension,
+    resolve_embedding_model,
 )
 
 try:
@@ -51,9 +51,7 @@ def main(
     port: int,
     model_id: str | None = None,
     embedding_model_id: str | None = None,
-    doc_text: str = (
-        "OGX provides a unified API to build AI applications with models, tools, and vector stores."
-    ),
+    doc_text: str = ("OGX provides a unified API to build AI applications with models, tools, and vector stores."),
     question: str = "What does OGX provide?",
 ) -> None:
     _maybe_load_dotenv()

--- a/demos/03_rag/02_multi_source_rag.py
+++ b/demos/03_rag/02_multi_source_rag.py
@@ -19,8 +19,8 @@ Learning Objectives:
 
 from __future__ import annotations
 
-from io import BytesIO
 import os
+from io import BytesIO
 from uuid import uuid4
 
 import fire
@@ -31,8 +31,8 @@ from demos.shared.utils import (
     can_model_chat,
     check_model_is_available,
     get_any_available_chat_model,
-    resolve_embedding_model,
     get_embedding_dimension,
+    resolve_embedding_model,
 )
 
 try:
@@ -46,9 +46,7 @@ def _maybe_load_dotenv() -> None:
         load_dotenv()
 
 
-def _create_vector_store(
-    client: OgxClient, provider_id: str, embedding_model: str, embedding_dimension: int
-):
+def _create_vector_store(client: OgxClient, provider_id: str, embedding_model: str, embedding_dimension: int):
     # Each vector store can hold its own document set.
     return client.vector_stores.create(
         name=f"multi_source_{uuid4()}",
@@ -60,9 +58,7 @@ def _create_vector_store(
     )
 
 
-def _attach_text(
-    client: OgxClient, vector_store_id: str, text: str, filename: str
-) -> None:
+def _attach_text(client: OgxClient, vector_store_id: str, text: str, filename: str) -> None:
     # Upload inline text as a file and attach it to the vector store.
     file_buffer = BytesIO(text.encode("utf-8"))
     file_buffer.name = filename

--- a/demos/03_rag/03_rag_with_metadata.py
+++ b/demos/03_rag/03_rag_with_metadata.py
@@ -19,8 +19,8 @@ Learning Objectives:
 
 from __future__ import annotations
 
-from io import BytesIO
 import os
+from io import BytesIO
 from uuid import uuid4
 
 import fire
@@ -31,8 +31,8 @@ from demos.shared.utils import (
     can_model_chat,
     check_model_is_available,
     get_any_available_chat_model,
-    resolve_embedding_model,
     get_embedding_dimension,
+    resolve_embedding_model,
 )
 
 try:

--- a/demos/03_rag/04_chunking_strategies.py
+++ b/demos/03_rag/04_chunking_strategies.py
@@ -19,8 +19,8 @@ Learning Objectives:
 
 from __future__ import annotations
 
-from io import BytesIO
 import os
+from io import BytesIO
 from uuid import uuid4
 
 import fire
@@ -31,8 +31,8 @@ from demos.shared.utils import (
     can_model_chat,
     check_model_is_available,
     get_any_available_chat_model,
-    resolve_embedding_model,
     get_embedding_dimension,
+    resolve_embedding_model,
 )
 
 try:

--- a/demos/03_rag/05_hybrid_search.py
+++ b/demos/03_rag/05_hybrid_search.py
@@ -19,8 +19,8 @@ Learning Objectives:
 
 from __future__ import annotations
 
-from io import BytesIO
 import os
+from io import BytesIO
 from uuid import uuid4
 
 import fire
@@ -32,8 +32,8 @@ from demos.shared.utils import (
     can_model_chat,
     check_model_is_available,
     get_any_available_chat_model,
-    resolve_embedding_model,
     get_embedding_dimension,
+    resolve_embedding_model,
 )
 
 try:
@@ -282,15 +282,12 @@ def main(
         final_response = client.responses.create(
             model=resolved_model,
             instructions=(
-                "Answer the question using the local context and web sources. "
-                "If a source is missing, say so briefly."
+                "Answer the question using the local context and web sources. If a source is missing, say so briefly."
             ),
             input=[
                 {
                     "role": "user",
-                    "content": (
-                        f"{local_context}\n\nWeb sources:\n{web_context}\n\nQuestion: {question}"
-                    ),
+                    "content": (f"{local_context}\n\nWeb sources:\n{web_context}\n\nQuestion: {question}"),
                 }
             ],
             stream=False,

--- a/demos/04_agents/01_simple_agent_chat.py
+++ b/demos/04_agents/01_simple_agent_chat.py
@@ -26,7 +26,7 @@ try:
     from dotenv import load_dotenv
 except Exception:
     load_dotenv = None
-from ogx_client import OgxClient, Agent, AgentEventLogger
+from ogx_client import Agent, AgentEventLogger, OgxClient
 from termcolor import colored
 
 from demos.shared.utils import check_model_is_available, get_any_available_chat_model

--- a/demos/04_agents/02_chat_multimodal.py
+++ b/demos/04_agents/02_chat_multimodal.py
@@ -52,19 +52,11 @@ def main(host: str, port: int, model_id: str | None = None):
     )
 
     if model_id is None:
-        print(
-            colored(
-                "No model id provided. Specify a model that supports vision.", "red"
-            )
-        )
+        print(colored("No model id provided. Specify a model that supports vision.", "red"))
         return
     else:
         if not check_model_is_available(client, model_id):
-            print(
-                colored(
-                    "Model not available. Specify a model that supports vision.", "red"
-                )
-            )
+            print(colored("Model not available. Specify a model that supports vision.", "red"))
             return
 
     agent = Agent(

--- a/demos/04_agents/03_chat_with_documents.py
+++ b/demos/04_agents/03_chat_with_documents.py
@@ -32,11 +32,11 @@ from termcolor import colored
 
 from demos.shared.utils import (
     build_context,
-    download_documents,
     check_model_is_available,
+    download_documents,
     get_any_available_chat_model,
-    resolve_embedding_model,
     get_embedding_dimension,
+    resolve_embedding_model,
 )
 
 
@@ -126,8 +126,7 @@ def main(
                     else:
                         print(
                             colored(
-                                f"Failed to attach {doc_path.name}"
-                                + (f": {error_message}" if error_message else ""),
+                                f"Failed to attach {doc_path.name}" + (f": {error_message}" if error_message else ""),
                                 "red",
                             )
                         )

--- a/demos/04_agents/04_agent_with_tools.py
+++ b/demos/04_agents/04_agent_with_tools.py
@@ -18,20 +18,19 @@ Learning Objectives:
 """
 
 import os
+
 import fire
 
 try:
     from dotenv import load_dotenv
 except Exception:
     load_dotenv = None
+from ogx_client import Agent, AgentEventLogger, OgxClient
 from termcolor import colored
 
+from demos.client_tools.calculator import calculator
 from demos.client_tools.ticker_data import get_ticker_data
 from demos.client_tools.web_search import WebSearchTool
-from demos.client_tools.calculator import calculator
-
-from ogx_client import OgxClient, Agent, AgentEventLogger
-
 from demos.shared.utils import can_model_chat, check_model_is_available, get_any_available_chat_model
 
 

--- a/demos/04_agents/05_rag_agent.py
+++ b/demos/04_agents/05_rag_agent.py
@@ -29,6 +29,7 @@ try:
 except Exception:
     load_dotenv = None
 import time
+
 from ogx_client import Agent, AgentEventLogger, OgxClient
 from termcolor import colored
 
@@ -36,8 +37,8 @@ from demos.shared.utils import (
     can_model_chat,
     check_model_is_available,
     get_any_available_chat_model,
-    resolve_embedding_model,
     get_embedding_dimension,
+    resolve_embedding_model,
 )
 
 
@@ -57,8 +58,7 @@ def main(
         "lora_finetune.rst",
     ]
     document_urls = [
-        f"https://raw.githubusercontent.com/pytorch/torchtune/main/docs/source/tutorials/{url}"
-        for url in urls
+        f"https://raw.githubusercontent.com/pytorch/torchtune/main/docs/source/tutorials/{url}" for url in urls
     ]
 
     client = OgxClient(base_url=f"http://{host}:{port}")
@@ -90,9 +90,7 @@ def main(
         print(colored("Unable to determine embedding dimension.", "red"))
         return
 
-    vector_providers = [
-        provider for provider in client.providers.list() if provider.api == "vector_io"
-    ]
+    vector_providers = [provider for provider in client.providers.list() if provider.api == "vector_io"]
     if not vector_providers:
         print(colored("No available vector_io providers. Exiting.", "red"))
         return

--- a/demos/04_agents/07_agent_routing.py
+++ b/demos/04_agents/07_agent_routing.py
@@ -26,13 +26,12 @@ try:
     from dotenv import load_dotenv
 except Exception:
     load_dotenv = None
+from ogx_client import Agent, OgxClient
 from termcolor import colored
 
 from demos.client_tools.calculator import calculator
 from demos.client_tools.ticker_data import get_ticker_data
 from demos.client_tools.web_search import WebSearchTool
-from ogx_client import Agent, OgxClient
-
 from demos.shared.utils import can_model_chat, check_model_is_available, get_any_available_chat_model
 
 
@@ -72,9 +71,7 @@ def _route_subtask(prompt: str, web_available: bool) -> str:
         return "finance"
     if any(token in lower_prompt for token in ["calculate", "sum", "math"]):
         return "math"
-    if any(char.isdigit() for char in lower_prompt) and any(
-        token in lower_prompt for token in ["+", "-", "*", "/"]
-    ):
+    if any(char.isdigit() for char in lower_prompt) and any(token in lower_prompt for token in ["+", "-", "*", "/"]):
         return "math"
     if any(token in lower_prompt for token in ["latest", "who", "when"]):
         return "research" if web_available else "general"
@@ -174,10 +171,7 @@ def main(host: str, port: int, model_id: str | None = None):
         subtask_results.append(f"- {subtask}\n  Result: {text_output}")
         print(text_output)
 
-    synthesis = (
-        "Synthesize the following subtask results into a concise update:\n\n"
-        + "\n\n".join(subtask_results)
-    )
+    synthesis = "Synthesize the following subtask results into a concise update:\n\n" + "\n\n".join(subtask_results)
     coordinator = agents["general"]
     coordinator_session = sessions["general"]
     print(colored("[coordination] synthesizing final response", "green"))

--- a/demos/06_openai_compatibility/01_chat_completion.py
+++ b/demos/06_openai_compatibility/01_chat_completion.py
@@ -20,13 +20,11 @@ Learning Objectives:
 from __future__ import annotations
 
 import os
-import sys
 
 import fire
 from openai import OpenAI
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
-from shared.utils import resolve_openai_model
+from demos.shared.utils import resolve_openai_model
 
 try:
     from dotenv import load_dotenv

--- a/demos/06_openai_compatibility/02_tool_calling.py
+++ b/demos/06_openai_compatibility/02_tool_calling.py
@@ -138,9 +138,7 @@ def main(
         except (json.JSONDecodeError, ValueError) as exc:
             result = json.dumps({"error": f"Invalid arguments for {fn_name}: {exc}"})
             print(colored(f"Tool result: {result}", "yellow"))
-            messages.append(
-                {"role": "tool", "tool_call_id": tool_call.id, "content": result}
-            )
+            messages.append({"role": "tool", "tool_call_id": tool_call.id, "content": result})
             continue
         print(colored(f"Tool call: {fn_name}({fn_args})", "yellow"))
 

--- a/demos/06_openai_compatibility/02_tool_calling.py
+++ b/demos/06_openai_compatibility/02_tool_calling.py
@@ -23,14 +23,12 @@ from __future__ import annotations
 
 import json
 import os
-import sys
 
 import fire
 from openai import OpenAI
 from termcolor import colored
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
-from shared.utils import resolve_openai_model
+from demos.shared.utils import resolve_openai_model
 
 try:
     from dotenv import load_dotenv

--- a/demos/06_openai_compatibility/03_responses_api.py
+++ b/demos/06_openai_compatibility/03_responses_api.py
@@ -20,14 +20,12 @@ Learning Objectives:
 from __future__ import annotations
 
 import os
-import sys
 
 import fire
 from openai import OpenAI
 from termcolor import colored
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
-from shared.utils import resolve_openai_model
+from demos.shared.utils import resolve_openai_model
 
 try:
     from dotenv import load_dotenv

--- a/demos/06_openai_compatibility/04_responses_max_output_tokens.py
+++ b/demos/06_openai_compatibility/04_responses_max_output_tokens.py
@@ -21,14 +21,12 @@ Learning Objectives:
 from __future__ import annotations
 
 import os
-import sys
 
 import fire
 from openai import OpenAI
 from termcolor import colored
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
-from shared.utils import resolve_openai_model
+from demos.shared.utils import resolve_openai_model
 
 try:
     from dotenv import load_dotenv

--- a/demos/06_openai_compatibility/05_responses_top_p.py
+++ b/demos/06_openai_compatibility/05_responses_top_p.py
@@ -22,14 +22,12 @@ Learning Objectives:
 from __future__ import annotations
 
 import os
-import sys
 
 import fire
 from openai import OpenAI
 from termcolor import colored
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
-from shared.utils import resolve_openai_model
+from demos.shared.utils import resolve_openai_model
 
 try:
     from dotenv import load_dotenv

--- a/demos/06_openai_compatibility/06_responses_truncation.py
+++ b/demos/06_openai_compatibility/06_responses_truncation.py
@@ -22,14 +22,12 @@ Learning Objectives:
 from __future__ import annotations
 
 import os
-import sys
 
 import fire
 from openai import OpenAI
 from termcolor import colored
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
-from shared.utils import resolve_openai_model
+from demos.shared.utils import resolve_openai_model
 
 try:
     from dotenv import load_dotenv

--- a/demos/06_openai_compatibility/07_responses_streaming.py
+++ b/demos/06_openai_compatibility/07_responses_streaming.py
@@ -21,14 +21,12 @@ Learning Objectives:
 from __future__ import annotations
 
 import os
-import sys
 
 import fire
 from openai import OpenAI
 from termcolor import colored
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
-from shared.utils import resolve_openai_model
+from demos.shared.utils import resolve_openai_model
 
 try:
     from dotenv import load_dotenv

--- a/demos/06_openai_compatibility/08_responses_parallel_tool_calls.py
+++ b/demos/06_openai_compatibility/08_responses_parallel_tool_calls.py
@@ -98,11 +98,13 @@ def _handle_tool_calls(response) -> list[dict]:
             else:
                 result = fn(**fn_args)
             print(colored(f"  Tool result: {result}", "yellow"))
-            results.append({
-                "type": "function_call_output",
-                "call_id": item.call_id,
-                "output": result,
-            })
+            results.append(
+                {
+                    "type": "function_call_output",
+                    "call_id": item.call_id,
+                    "output": result,
+                }
+            )
     return results
 
 
@@ -150,7 +152,11 @@ def main(
             model=resolved_model,
             input=[
                 {"role": "user", "content": prompt},
-                *[{"type": "function_call", "name": item.name, "call_id": item.call_id, "arguments": item.arguments} for item in response.output if item.type == "function_call"],
+                *[
+                    {"type": "function_call", "name": item.name, "call_id": item.call_id, "arguments": item.arguments}
+                    for item in response.output
+                    if item.type == "function_call"
+                ],
                 *tool_results,
             ],
             tools=TOOLS,
@@ -176,7 +182,11 @@ def main(
             model=resolved_model,
             input=[
                 {"role": "user", "content": prompt},
-                *[{"type": "function_call", "name": item.name, "call_id": item.call_id, "arguments": item.arguments} for item in response.output if item.type == "function_call"],
+                *[
+                    {"type": "function_call", "name": item.name, "call_id": item.call_id, "arguments": item.arguments}
+                    for item in response.output
+                    if item.type == "function_call"
+                ],
                 *tool_results,
             ],
             tools=TOOLS,

--- a/demos/06_openai_compatibility/08_responses_parallel_tool_calls.py
+++ b/demos/06_openai_compatibility/08_responses_parallel_tool_calls.py
@@ -22,14 +22,12 @@ from __future__ import annotations
 
 import json
 import os
-import sys
 
 import fire
 from openai import OpenAI
 from termcolor import colored
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
-from shared.utils import resolve_openai_model
+from demos.shared.utils import resolve_openai_model
 
 try:
     from dotenv import load_dotenv

--- a/demos/06_openai_compatibility/09_responses_service_tier.py
+++ b/demos/06_openai_compatibility/09_responses_service_tier.py
@@ -22,14 +22,12 @@ Learning Objectives:
 from __future__ import annotations
 
 import os
-import sys
 
 import fire
 from openai import OpenAI
 from termcolor import colored
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
-from shared.utils import resolve_openai_model
+from demos.shared.utils import resolve_openai_model
 
 try:
     from dotenv import load_dotenv

--- a/demos/06_openai_compatibility/10_responses_logprobs.py
+++ b/demos/06_openai_compatibility/10_responses_logprobs.py
@@ -81,8 +81,7 @@ def main(
                 if hasattr(content_part, "logprobs") and content_part.logprobs:
                     print(colored("\nToken logprobs (first 5 positions):", "cyan"))
                     for i, token_logprob in enumerate(content_part.logprobs[:5]):
-                        print(f"  Position {i}: token='{token_logprob.token}' "
-                              f"logprob={token_logprob.logprob:.4f}")
+                        print(f"  Position {i}: token='{token_logprob.token}' logprob={token_logprob.logprob:.4f}")
                         if hasattr(token_logprob, "top_logprobs") and token_logprob.top_logprobs:
                             for alt in token_logprob.top_logprobs:
                                 print(f"    alt: '{alt.token}' logprob={alt.logprob:.4f}")

--- a/demos/06_openai_compatibility/10_responses_logprobs.py
+++ b/demos/06_openai_compatibility/10_responses_logprobs.py
@@ -21,14 +21,12 @@ Learning Objectives:
 from __future__ import annotations
 
 import os
-import sys
 
 import fire
 from openai import OpenAI
 from termcolor import colored
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
-from shared.utils import resolve_openai_model
+from demos.shared.utils import resolve_openai_model
 
 try:
     from dotenv import load_dotenv

--- a/demos/06_openai_compatibility/11_responses_reasoning.py
+++ b/demos/06_openai_compatibility/11_responses_reasoning.py
@@ -22,14 +22,12 @@ Learning Objectives:
 from __future__ import annotations
 
 import os
-import sys
 
 import fire
 from openai import OpenAI
 from termcolor import colored
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
-from shared.utils import resolve_openai_model
+from demos.shared.utils import resolve_openai_model
 
 try:
     from dotenv import load_dotenv

--- a/demos/06_openai_compatibility/12_responses_temperature.py
+++ b/demos/06_openai_compatibility/12_responses_temperature.py
@@ -75,7 +75,7 @@ def main(
             input=prompt,
             temperature=0.0,
         )
-        print(f"  Run {i+1}: {response.output_text}")
+        print(f"  Run {i + 1}: {response.output_text}")
 
     # --- Example 2: Medium temperature ---
     print(colored("\n--- temperature=0.7 (balanced) ---", "cyan"))
@@ -85,7 +85,7 @@ def main(
             input=prompt,
             temperature=0.7,
         )
-        print(f"  Run {i+1}: {response.output_text}")
+        print(f"  Run {i + 1}: {response.output_text}")
 
     # --- Example 3: High temperature (creative) ---
     print(colored("\n--- temperature=1.5 (creative) ---", "cyan"))
@@ -95,7 +95,7 @@ def main(
             input=prompt,
             temperature=1.5,
         )
-        print(f"  Run {i+1}: {response.output_text}")
+        print(f"  Run {i + 1}: {response.output_text}")
 
 
 if __name__ == "__main__":

--- a/demos/06_openai_compatibility/12_responses_temperature.py
+++ b/demos/06_openai_compatibility/12_responses_temperature.py
@@ -22,14 +22,12 @@ Learning Objectives:
 from __future__ import annotations
 
 import os
-import sys
 
 import fire
 from openai import OpenAI
 from termcolor import colored
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
-from shared.utils import resolve_openai_model
+from demos.shared.utils import resolve_openai_model
 
 try:
     from dotenv import load_dotenv

--- a/demos/06_openai_compatibility/13_responses_combined.py
+++ b/demos/06_openai_compatibility/13_responses_combined.py
@@ -22,14 +22,12 @@ Learning Objectives:
 from __future__ import annotations
 
 import os
-import sys
 
 import fire
 from openai import OpenAI
 from termcolor import colored
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
-from shared.utils import resolve_openai_model
+from demos.shared.utils import resolve_openai_model
 
 try:
     from dotenv import load_dotenv

--- a/demos/06_openai_compatibility/13_responses_combined.py
+++ b/demos/06_openai_compatibility/13_responses_combined.py
@@ -80,8 +80,7 @@ def main(
     print(f"Output: {response.output_text}")
     print(f"Status: {response.status}")
     if hasattr(response, "usage") and response.usage:
-        print(colored(f"Usage - Input: {response.usage.input_tokens}, "
-                      f"Output: {response.usage.output_tokens}", "green"))
+        print(colored(f"Usage - Input: {response.usage.input_tokens}, Output: {response.usage.output_tokens}", "green"))
 
     # --- Example 2: Precise factual response ---
     print(colored("\n--- Factual Q&A with combined params ---", "cyan"))

--- a/demos/client_tools/calculator.py
+++ b/demos/client_tools/calculator.py
@@ -1,4 +1,5 @@
 import logging
+
 from ogx_client.lib.agents.client_tool import client_tool
 
 # Set up logging

--- a/demos/client_tools/ticker_data.py
+++ b/demos/client_tools/ticker_data.py
@@ -7,7 +7,6 @@ import json
 
 import pandas as pd
 import yfinance as yf
-
 from ogx_client.lib.agents.client_tool import client_tool
 
 

--- a/demos/client_tools/web_search.py
+++ b/demos/client_tools/web_search.py
@@ -6,11 +6,10 @@
 
 import asyncio
 import json
-from typing import Dict, Any
+from typing import Any
 
 import httpx
 import requests
-
 from ogx_client.lib.agents.client_tool import ClientTool
 
 
@@ -33,9 +32,8 @@ class BraveSearch:
     def _clean_brave_response(self, search_response, top_k=3):
         query = None
         clean_response = []
-        if "query" in search_response:
-            if "original" in search_response["query"]:
-                query = search_response["query"]["original"]
+        if "query" in search_response and "original" in search_response["query"]:
+            query = search_response["query"]["original"]
         if "mixed" in search_response:
             mixed_results = search_response["mixed"]
             for m in mixed_results["main"][:top_k]:
@@ -52,17 +50,13 @@ class BraveSearch:
                         "date",
                         "extra_snippets",
                     ]
-                    cleaned = {
-                        k: v for k, v in results[idx].items() if k in selected_keys
-                    }
+                    cleaned = {k: v for k, v in results[idx].items() if k in selected_keys}
                 elif r_type == "faq":
                     # For FAQ data - take a list of all the questions & answers
                     selected_keys = ["type", "question", "answer", "title", "url"]
                     cleaned = []
                     for q in results:
-                        cleaned.append(
-                            {k: v for k, v in q.items() if k in selected_keys}
-                        )
+                        cleaned.append({k: v for k, v in q.items() if k in selected_keys})
                 elif r_type == "infobox":
                     idx = m["index"]
                     selected_keys = [
@@ -72,9 +66,7 @@ class BraveSearch:
                         "description",
                         "long_desc",
                     ]
-                    cleaned = {
-                        k: v for k, v in results[idx].items() if k in selected_keys
-                    }
+                    cleaned = {k: v for k, v in results[idx].items() if k in selected_keys}
                 elif r_type == "videos":
                     selected_keys = [
                         "type",
@@ -85,9 +77,7 @@ class BraveSearch:
                     ]
                     cleaned = []
                     for q in results:
-                        cleaned.append(
-                            {k: v for k, v in q.items() if k in selected_keys}
-                        )
+                        cleaned.append({k: v for k, v in q.items() if k in selected_keys})
                 elif r_type == "locations":
                     # For location data - take a list of all the locations
                     selected_keys = [
@@ -104,9 +94,7 @@ class BraveSearch:
                     ]
                     cleaned = []
                     for q in results:
-                        cleaned.append(
-                            {k: v for k, v in q.items() if k in selected_keys}
-                        )
+                        cleaned.append({k: v for k, v in q.items() if k in selected_keys})
                 elif r_type == "news":
                     # For news data - take a list of all the news articles
                     selected_keys = [
@@ -117,9 +105,7 @@ class BraveSearch:
                     ]
                     cleaned = []
                     for q in results:
-                        cleaned.append(
-                            {k: v for k, v in q.items() if k in selected_keys}
-                        )
+                        cleaned.append({k: v for k, v in q.items() if k in selected_keys})
                 else:
                     cleaned = []
 
@@ -165,9 +151,7 @@ class WebSearchTool(ClientTool):
 
     def __init__(self, engine: str, api_key: str):
         self.api_key = api_key
-        assert engine in ["brave", "tavily"], (
-            "Invalid engine, use one of brave or tavily"
-        )
+        assert engine in ["brave", "tavily"], "Invalid engine, use one of brave or tavily"
         if engine == "brave":
             self.engine = BraveSearch(api_key)
         else:
@@ -179,7 +163,7 @@ class WebSearchTool(ClientTool):
     def get_description(self) -> str:
         return "Search the web for a given query"
 
-    def get_input_schema(self) -> Dict[str, Any]:
+    def get_input_schema(self) -> dict[str, Any]:
         return {
             "type": "object",
             "properties": {

--- a/demos/shared/utils.py
+++ b/demos/shared/utils.py
@@ -51,11 +51,7 @@ def resolve_model(client: OgxClient, model_id: str | None, env_var: str = "OGX_C
     if resolved:
         return resolved
 
-    candidates = [
-        _get_model_id(m)
-        for m in _list_models(client)
-        if _is_llm_model(m) and _get_model_id(m)
-    ]
+    candidates = [_get_model_id(m) for m in _list_models(client) if _is_llm_model(m) and _get_model_id(m)]
 
     for mid in candidates:
         if can_model_chat(client, mid):
@@ -114,11 +110,7 @@ def get_any_available_model(client: OgxClient):
     resolved = os.getenv("OGX_CHAT_MODEL") or None
     if resolved:
         return resolved
-    candidates = [
-        _get_model_id(m)
-        for m in _list_models(client)
-        if _is_llm_model(m) and _get_model_id(m)
-    ]
+    candidates = [_get_model_id(m) for m in _list_models(client) if _is_llm_model(m) and _get_model_id(m)]
     if not candidates:
         print(colored("No available models.", "red"))
         return None
@@ -130,11 +122,7 @@ def get_any_available_chat_model(client: OgxClient):
     if resolved:
         return resolved
 
-    candidates = [
-        _get_model_id(m)
-        for m in _list_models(client)
-        if _is_llm_model(m) and _get_model_id(m)
-    ]
+    candidates = [_get_model_id(m) for m in _list_models(client) if _is_llm_model(m) and _get_model_id(m)]
     if not candidates:
         print(colored("No available models.", "red"))
         return None
@@ -157,9 +145,7 @@ def resolve_embedding_model(client: OgxClient, model_id: str | None = None) -> s
 
 def _get_any_embedding_model(client: OgxClient) -> str | None:
     embedding_models = [
-        _get_model_id(m)
-        for m in _list_models(client)
-        if _get_model_id(m) and _get_model_type(m) == "embedding"
+        _get_model_id(m) for m in _list_models(client) if _get_model_id(m) and _get_model_type(m) == "embedding"
     ]
     if not embedding_models:
         print(colored("No available embedding models.", "red"))
@@ -220,9 +206,7 @@ def build_context(search_results) -> str:
         return ""
     context_lines = ["Context from uploaded documents:"]
     for result in search_results:
-        snippet = " ".join(
-            content.text.strip() for content in result.content if getattr(content, "text", None)
-        ).strip()
+        snippet = " ".join(content.text.strip() for content in result.content if getattr(content, "text", None)).strip()
         if not snippet:
             continue
         score = result.score if result.score is not None else 0.0

--- a/deployment/kubernetes/mcp-servers/math-mcp/server.py
+++ b/deployment/kubernetes/mcp-servers/math-mcp/server.py
@@ -4,12 +4,13 @@ Math MCP Server - Simple HTTP version
 A basic HTTP server that exposes math operations and MCP-compatible endpoints.
 """
 
-import math
 import logging
-from typing import Any, Dict, List
+import math
+from typing import Any
+
+import uvicorn
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
-import uvicorn
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
@@ -38,12 +39,12 @@ class MathResult(BaseModel):
 class MCPTool(BaseModel):
     name: str
     description: str
-    inputSchema: Dict
+    inputSchema: dict
 
 
 # MCP Protocol Models
 class MCPListToolsResponse(BaseModel):
-    tools: List[MCPTool]
+    tools: list[MCPTool]
 
 
 @app.get("/")
@@ -53,11 +54,7 @@ async def root():
         "service": "Math MCP Server",
         "status": "running",
         "version": "1.0.0",
-        "endpoints": {
-            "health": "/health",
-            "mcp_tools": "/mcp/tools",
-            "calculate": "/calculate"
-        }
+        "endpoints": {"health": "/health", "mcp_tools": "/mcp/tools", "calculate": "/calculate"},
     }
 
 
@@ -207,7 +204,7 @@ async def calculate(op: MathOperation) -> MathResult:
         elif operation == "power":
             if op.base is None or op.exponent is None:
                 raise HTTPException(status_code=400, detail="Parameters 'base' and 'exponent' are required")
-            result = op.base ** op.exponent
+            result = op.base**op.exponent
             return MathResult(result=result, message=f"{op.base} ^ {op.exponent} = {result}")
 
         elif operation == "sqrt":
@@ -239,7 +236,7 @@ async def calculate(op: MathOperation) -> MathResult:
         raise
     except Exception as e:
         logger.error(f"Error executing {operation}: {str(e)}")
-        raise HTTPException(status_code=500, detail=f"Error executing operation: {str(e)}")
+        raise HTTPException(status_code=500, detail=f"Error executing operation: {str(e)}") from e
 
 
 @app.get("/sse")
@@ -247,15 +244,10 @@ async def sse_endpoint():
     """SSE endpoint placeholder for MCP protocol"""
     return {
         "message": "MCP SSE transport not yet implemented",
-        "alternative": "Use /mcp/tools to list tools and /calculate to execute operations"
+        "alternative": "Use /mcp/tools to list tools and /calculate to execute operations",
     }
 
 
 if __name__ == "__main__":
     logger.info("Starting Math MCP Server on port 8080")
-    uvicorn.run(
-        app,
-        host="0.0.0.0",
-        port=8080,
-        log_level="info"
-    )
+    uvicorn.run(app, host="0.0.0.0", port=8080, log_level="info")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,3 +20,29 @@ dependencies = [
     "python-multipart>=0.0.20",
     "yfinance>=0.2.0",
 ]
+
+[tool.ruff]
+target-version = "py312"
+line-length = 120
+extend-exclude = [
+    "demos/rag_eval",
+    "tests/eval_tests",
+]
+
+[tool.ruff.lint]
+select = [
+    "E",    # pycodestyle errors
+    "W",    # pycodestyle warnings
+    "F",    # pyflakes
+    "I",    # isort
+    "UP",   # pyupgrade
+    "B",    # flake8-bugbear
+    "SIM",  # flake8-simplify
+]
+ignore = [
+    "E501",   # line length — handled by the formatter
+    "SIM108", # ternary operator — often less readable
+]
+
+[tool.ruff.lint.isort]
+known-first-party = ["demos"]

--- a/scripts/validate_demos.py
+++ b/scripts/validate_demos.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Validate demo files meet structural requirements.
+
+Uses only the ast module — no third-party dependencies, no OGX server needed.
+Runs both in pre-commit (on changed files) and in CI (on all demo files).
+
+Usage:
+    # Validate specific files (pre-commit passes changed files)
+    python scripts/validate_demos.py demos/01_foundations/01_client_setup.py
+
+    # Validate all demo files
+    python scripts/validate_demos.py
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEMO_DIR = REPO_ROOT / "demos"
+
+DEMO_FILE_PATTERN = re.compile(r"^\d{2}_[a-z][a-z0-9_]*\.py$")
+
+REQUIRED_DOCSTRING_FIELDS = ["Demo:", "Description:", "Learning Objectives:"]
+
+SKIP_FILES = {"_template.py"}
+
+
+def find_demo_files() -> list[Path]:
+    """Find all demo Python files matching NN_name.py in phase directories."""
+    files = []
+    for phase_dir in sorted(DEMO_DIR.iterdir()):
+        if not phase_dir.is_dir():
+            continue
+        if not re.match(r"\d{2}_", phase_dir.name):
+            continue
+        for py_file in sorted(phase_dir.glob("*.py")):
+            if py_file.name.startswith("__"):
+                continue
+            if py_file.name in SKIP_FILES:
+                continue
+            files.append(py_file)
+    return files
+
+
+def validate_file(path: Path) -> tuple[list[str], list[str]]:
+    """Validate a single demo file. Returns (errors, warnings)."""
+    errors = []
+    warnings = []
+    relative = path.relative_to(REPO_ROOT) if path.is_relative_to(REPO_ROOT) else path
+
+    try:
+        source = path.read_text(encoding="utf-8")
+    except OSError as e:
+        return [f"{relative}: cannot read file: {e}"], []
+
+    try:
+        tree = ast.parse(source, filename=str(path))
+    except SyntaxError as e:
+        return [f"{relative}: syntax error: {e}"], []
+
+    # 1. File naming
+    if not DEMO_FILE_PATTERN.match(path.name):
+        errors.append(
+            f"{relative}: file name '{path.name}' does not match pattern NN_snake_case_name.py"
+        )
+
+    # 2. Module docstring with required fields
+    docstring = ast.get_docstring(tree)
+    if docstring is None:
+        errors.append(f"{relative}: missing module docstring")
+    else:
+        for field in REQUIRED_DOCSTRING_FIELDS:
+            if field not in docstring:
+                errors.append(f"{relative}: docstring missing required field '{field}'")
+
+    # 3. if __name__ == "__main__" block with fire.Fire(...)
+    has_main_guard = False
+    fire_target = None
+    for node in ast.iter_child_nodes(tree):
+        if not isinstance(node, ast.If):
+            continue
+        if _is_name_main_check(node.test):
+            has_main_guard = True
+            for stmt in ast.walk(node):
+                target = _get_fire_target(stmt)
+                if target is not None:
+                    fire_target = target
+                    break
+            break
+
+    if not has_main_guard:
+        errors.append(f"{relative}: missing 'if __name__ == \"__main__\"' guard")
+    elif fire_target is None:
+        errors.append(f"{relative}: 'if __name__' block does not call fire.Fire(...)")
+
+    # 4. main() function with host and port parameters
+    #    Only required when fire.Fire is called with main (not a dict dispatch).
+    if fire_target == "main":
+        main_func = None
+        for node in ast.iter_child_nodes(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == "main":
+                main_func = node
+                break
+
+        if main_func is None:
+            errors.append(f"{relative}: missing top-level main() function")
+        else:
+            param_names = [arg.arg for arg in main_func.args.args]
+            if "host" not in param_names:
+                errors.append(f"{relative}: main() missing 'host' parameter")
+            if "port" not in param_names:
+                errors.append(f"{relative}: main() missing 'port' parameter")
+
+    # 5. Warn on sys.path manipulation (non-blocking)
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and isinstance(node.func.value, ast.Attribute)
+            and node.func.attr in ("insert", "append")
+            and _is_sys_path(node.func.value)
+        ):
+                warnings.append(
+                    f"{relative}:{node.lineno}: uses sys.path manipulation — "
+                    "use package imports instead (from demos.shared.utils import ...)"
+                )
+
+    return errors, warnings
+
+
+def _is_name_main_check(node: ast.expr) -> bool:
+    """Check if an AST node is `__name__ == '__main__'`."""
+    if not isinstance(node, ast.Compare):
+        return False
+    if len(node.ops) != 1 or not isinstance(node.ops[0], ast.Eq):
+        return False
+    left = node.left
+    comparators = node.comparators
+    if len(comparators) != 1:
+        return False
+    right = comparators[0]
+
+    def is_name(n: ast.expr) -> bool:
+        return isinstance(n, ast.Name) and n.id == "__name__"
+
+    def is_main_str(n: ast.expr) -> bool:
+        return isinstance(n, ast.Constant) and n.value == "__main__"
+
+    return (is_name(left) and is_main_str(right)) or (is_main_str(left) and is_name(right))
+
+
+def _get_fire_target(node: ast.AST) -> str | None:
+    """Return the target of fire.Fire(...), or None if not a fire.Fire call.
+
+    Returns "main" for fire.Fire(main), "dict" for fire.Fire({...}), or
+    "other" for any other fire.Fire(...) call.
+    """
+    if not isinstance(node, ast.Expr):
+        return None
+    call = node.value
+    if not isinstance(call, ast.Call):
+        return None
+    func = call.func
+    if not (isinstance(func, ast.Attribute) and func.attr == "Fire"):
+        return None
+    if not (isinstance(func.value, ast.Name) and func.value.id == "fire"):
+        return None
+    if call.args and isinstance(call.args[0], ast.Name) and call.args[0].id == "main":
+        return "main"
+    if call.args and isinstance(call.args[0], ast.Dict):
+        return "dict"
+    return "other"
+
+
+def _is_sys_path(node: ast.expr) -> bool:
+    """Check if an AST node is `sys.path`."""
+    return (
+        isinstance(node, ast.Attribute)
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "sys"
+        and node.attr == "path"
+    )
+
+
+def main() -> int:
+    if len(sys.argv) > 1:
+        files = [Path(f) for f in sys.argv[1:]]
+    else:
+        files = find_demo_files()
+
+    if not files:
+        print("No demo files to validate.")
+        return 0
+
+    all_errors = []
+    all_warnings = []
+    for f in files:
+        file_errors, file_warnings = validate_file(f)
+        all_errors.extend(file_errors)
+        all_warnings.extend(file_warnings)
+
+    if all_warnings:
+        print(f"Warnings ({len(all_warnings)}):\n")
+        for warning in all_warnings:
+            print(f"  {warning}")
+        print()
+
+    if all_errors:
+        print(f"Found {len(all_errors)} validation error(s):\n")
+        for error in all_errors:
+            print(f"  {error}")
+        return 1
+
+    print(f"Validated {len(files)} demo file(s) — all passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate_demos.py
+++ b/scripts/validate_demos.py
@@ -64,9 +64,7 @@ def validate_file(path: Path) -> tuple[list[str], list[str]]:
 
     # 1. File naming
     if not DEMO_FILE_PATTERN.match(path.name):
-        errors.append(
-            f"{relative}: file name '{path.name}' does not match pattern NN_snake_case_name.py"
-        )
+        errors.append(f"{relative}: file name '{path.name}' does not match pattern NN_snake_case_name.py")
 
     # 2. Module docstring with required fields
     docstring = ast.get_docstring(tree)
@@ -124,10 +122,10 @@ def validate_file(path: Path) -> tuple[list[str], list[str]]:
             and node.func.attr in ("insert", "append")
             and _is_sys_path(node.func.value)
         ):
-                warnings.append(
-                    f"{relative}:{node.lineno}: uses sys.path manipulation — "
-                    "use package imports instead (from demos.shared.utils import ...)"
-                )
+            warnings.append(
+                f"{relative}:{node.lineno}: uses sys.path manipulation — "
+                "use package imports instead (from demos.shared.utils import ...)"
+            )
 
     return errors, warnings
 

--- a/tests/scripts/0_simple_agent.py
+++ b/tests/scripts/0_simple_agent.py
@@ -1,14 +1,13 @@
 # Code bellow written following examples here: https://ogx-ai.github.io/docs/building_applications
-from ogx_client.lib.agents.agent import Agent
-from ogx_client.lib.agents.event_logger import EventLogger
-from ogx_client import OgxClient
-from termcolor import cprint
 import argparse
 import logging
 import os
-from dotenv import load_dotenv
 
 from client_tools import torchtune
+from dotenv import load_dotenv
+from ogx_client import OgxClient
+from ogx_client.lib.agents.agent import Agent
+from ogx_client.lib.agents.event_logger import EventLogger
 
 load_dotenv()
 
@@ -16,7 +15,7 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 stream_handler = logging.StreamHandler()
 stream_handler.setLevel(logging.INFO)
-formatter = logging.Formatter('%(message)s')
+formatter = logging.Formatter("%(message)s")
 stream_handler.setFormatter(formatter)
 logger.addHandler(stream_handler)
 
@@ -24,18 +23,20 @@ logger.addHandler(stream_handler)
 parser = argparse.ArgumentParser()
 parser.add_argument("-r", "--remote", help="Uses the remote_url", action="store_true")
 parser.add_argument("-s", "--session-info-on-exit", help="Prints agent session info on exit", action="store_true")
-parser.add_argument("-a", "--auto", help="Automatically runs examples, and does not start a chat session", action="store_true")
+parser.add_argument(
+    "-a", "--auto", help="Automatically runs examples, and does not start a chat session", action="store_true"
+)
 args = parser.parse_args()
 
-model="meta-llama/Llama-3.2-3B-Instruct"
+model = "meta-llama/Llama-3.2-3B-Instruct"
 
 # Connect to an OGX server
 if args.remote:
     base_url = os.getenv("REMOTE_BASE_URL")
     mcp_url = os.getenv("REMOTE_MCP_URL")
 else:
-    base_url="http://localhost:8321"
-    mcp_url="http://host.containers.internal:8000/sse"
+    base_url = "http://localhost:8321"
+    mcp_url = "http://host.containers.internal:8000/sse"
 
 client = OgxClient(base_url=base_url)
 logger.info(f"Connected to OGX server @ {base_url} \n")
@@ -50,8 +51,8 @@ if "mcp::custom_tool" not in registered_toolgroups:
     client.toolgroups.register(
         toolgroup_id="mcp::custom_tool",
         provider_id="model-context-protocol",
-        mcp_endpoint={"uri":mcp_url},
-        )
+        mcp_endpoint={"uri": mcp_url},
+    )
 mcp_tools = [t.identifier for t in client.tools.list(toolgroup_id="mcp::custom_tool")]
 
 logger.info(f"""Your Server has access the the following toolgroups:
@@ -62,26 +63,23 @@ logger.info(f"""Your Server has access the the following toolgroups:
 agent = Agent(
     client,
     model=model,
-    instructions = """You are a helpful assistant. You have access to a number of tools.
+    instructions="""You are a helpful assistant. You have access to a number of tools.
     Whenever a tool is called, be sure return the Response in a friendly and helpful tone.
     When you are asked to search the web you must use a tool.
-    """ ,
+    """,
     tools=["mcp::custom_tool", torchtune],
-    tool_config={"tool_choice":"auto"}
+    tool_config={"tool_choice": "auto"},
 )
 
 if args.auto:
-    user_prompts = ["""please execute the client tool torchtune to answer the following question: what is torchtune?""",
-                    """give me a random number between 1 and 1010"""]
+    user_prompts = [
+        """please execute the client tool torchtune to answer the following question: what is torchtune?""",
+        """give me a random number between 1 and 1010""",
+    ]
     session_id = agent.create_session(session_name="Auto_demo")
     for prompt in user_prompts:
         turn_response = agent.create_turn(
-            messages=[
-                {
-                    "role":"user",
-                    "content": prompt
-                }
-            ],
+            messages=[{"role": "user", "content": prompt}],
             session_id=session_id,
             stream=True,
         )
@@ -89,14 +87,14 @@ if args.auto:
             log.print()
 
 else:
-    #Create a chat session
+    # Create a chat session
     session_id = agent.create_session(session_name="Conversation_demo")
     while True:
         user_input = input(">>> ")
         if "/bye" in user_input:
             if args.session_info_on_exit:
                 agent_session = client.agents.session.retrieve(session_id=session_id, agent_id=agent.agent_id)
-                print( agent_session.to_dict())
+                print(agent_session.to_dict())
             break
         turn_response = agent.create_turn(
             session_id=session_id,

--- a/tests/scripts/1_simple_agent_with_RAG.py
+++ b/tests/scripts/1_simple_agent_with_RAG.py
@@ -1,15 +1,14 @@
 # Code bellow written following examples here: https://ogx-ai.github.io/docs/building_applications
 # Code bellow written following examples here: https://ogx-ai.github.io/docs/building_applications/rag.html
-from ogx_client.lib.agents.agent import Agent
-from ogx_client.lib.agents.event_logger import EventLogger
-from ogx_client.types import Document
-
-from ogx_client import OgxClient
-from termcolor import cprint
 import argparse
 import logging
 import os
+
 from dotenv import load_dotenv
+from ogx_client import OgxClient
+from ogx_client.lib.agents.agent import Agent
+from ogx_client.lib.agents.event_logger import EventLogger
+from ogx_client.types import Document
 
 load_dotenv()
 
@@ -17,7 +16,7 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 stream_handler = logging.StreamHandler()
 stream_handler.setLevel(logging.INFO)
-formatter = logging.Formatter('%(message)s')
+formatter = logging.Formatter("%(message)s")
 stream_handler.setFormatter(formatter)
 logger.addHandler(stream_handler)
 
@@ -25,10 +24,12 @@ logger.addHandler(stream_handler)
 parser = argparse.ArgumentParser()
 parser.add_argument("-r", "--remote", help="Uses the remote_url", action="store_true")
 parser.add_argument("-s", "--session-info-on-exit", help="Prints agent session info on exit", action="store_true")
-parser.add_argument("-a", "--auto", help="Automatically runs examples, and does not start a chat session", action="store_true")
+parser.add_argument(
+    "-a", "--auto", help="Automatically runs examples, and does not start a chat session", action="store_true"
+)
 args = parser.parse_args()
 
-model="meta-llama/Llama-3.2-3B-Instruct"
+model = "meta-llama/Llama-3.2-3B-Instruct"
 
 # Connect to an OGX server
 if args.remote:
@@ -36,9 +37,9 @@ if args.remote:
     mcp_url = os.getenv("REMOTE_MCP_URL")
     vdb_provider = os.getenv("REMOTE_VDB_PROVIDER")
 else:
-    base_url="http://localhost:8321"
-    mcp_url="http://host.containers.internal:8000/sse"
-    vdb_provider="faiss"
+    base_url = "http://localhost:8321"
+    mcp_url = "http://host.containers.internal:8000/sse"
+    vdb_provider = "faiss"
 
 client = OgxClient(base_url=base_url)
 logger.info(f"Connected to OGX server @ {base_url} \n")
@@ -53,17 +54,17 @@ if "mcp::custom_tool" not in registered_toolgroups:
     client.toolgroups.register(
         toolgroup_id="mcp::custom_tool",
         provider_id="model-context-protocol",
-        mcp_endpoint={"uri":mcp_url},
-        )
+        mcp_endpoint={"uri": mcp_url},
+    )
 mcp_tools = [t.identifier for t in client.tools.list(toolgroup_id="mcp::custom_tool")]
 
 vector_db_ids = [vector_db.provider_resource_id for vector_db in client.vector_dbs.list()]
 if "my_documents" not in vector_db_ids:
     response = client.vector_dbs.register(
-    vector_db_id="my_documents",
-    embedding_model="all-MiniLM-L6-v2",
-    embedding_dimension=384,
-    provider_id=vdb_provider,
+        vector_db_id="my_documents",
+        embedding_model="all-MiniLM-L6-v2",
+        embedding_dimension=384,
+        provider_id=vdb_provider,
     )
 
     urls = ["https://raw.githubusercontent.com/ogx-ai/ogx/refs/heads/main/README.md"]
@@ -73,14 +74,15 @@ if "my_documents" not in vector_db_ids:
             content=doc,
             mime_type="text/pain",
             metadata={},
-        ) for i, doc in enumerate(urls)
-        ]
+        )
+        for i, doc in enumerate(urls)
+    ]
 
     client.tool_runtime.rag_tool.insert(
-    documents=documents,
-    vector_db_id="my_documents",
-    chunk_size_in_tokens=512,
-)
+        documents=documents,
+        vector_db_id="my_documents",
+        chunk_size_in_tokens=512,
+    )
 
 
 logger.info(f"""Your Server has access the the following toolgroups:
@@ -91,33 +93,32 @@ logger.info(f"""Your Server has access the the following toolgroups:
 agent = Agent(
     client,
     model=model,
-    instructions = """You are a helpful assistant. You have access to a number of tools.
+    instructions="""You are a helpful assistant. You have access to a number of tools.
     Whenever a tool is called, be sure return the Response in a friendly and helpful tone.
     When you are asked to search the web you must use a tool.
-    """ ,
-    tools=["mcp::custom_tool",{
-        "name":"builtin::rag",
-            "args":{
-                "vector_db_ids":["my_documents"],
+    """,
+    tools=[
+        "mcp::custom_tool",
+        {
+            "name": "builtin::rag",
+            "args": {
+                "vector_db_ids": ["my_documents"],
                 "top_k": 1,
-                }
-    }
+            },
+        },
     ],
-    tool_config={"tool_choice":"auto"}
+    tool_config={"tool_choice": "auto"},
 )
 
 if args.auto:
-    user_prompts = ["""Please use the knowledge search tool to tell me what you know about OGX.""",
-                    """Give me a random number between 1 and 1010."""]
+    user_prompts = [
+        """Please use the knowledge search tool to tell me what you know about OGX.""",
+        """Give me a random number between 1 and 1010.""",
+    ]
     session_id = agent.create_session(session_name="Auto_demo")
     for prompt in user_prompts:
         turn_response = agent.create_turn(
-            messages=[
-                {
-                    "role":"user",
-                    "content": prompt
-                }
-            ],
+            messages=[{"role": "user", "content": prompt}],
             session_id=session_id,
             stream=True,
         )
@@ -125,14 +126,14 @@ if args.auto:
             log.print()
 
 else:
-    #Create a chat session
+    # Create a chat session
     session_id = agent.create_session(session_name="Conversation_demo")
     while True:
         user_input = input(">>> ")
         if "/bye" in user_input:
             if args.session_info_on_exit:
                 agent_session = client.agents.session.retrieve(session_id=session_id, agent_id=agent.agent_id)
-                print( agent_session.to_dict())
+                print(agent_session.to_dict())
             break
         turn_response = agent.create_turn(
             session_id=session_id,

--- a/tests/scripts/4_OCP_version_info_email.py
+++ b/tests/scripts/4_OCP_version_info_email.py
@@ -1,11 +1,12 @@
-from ogx_client.lib.agents.agent import Agent
-from ogx_client.lib.agents.event_logger import EventLogger
-from ogx_client import OgxClient
 import argparse
 import logging
-import uuid
 import os
+import uuid
+
 from dotenv import load_dotenv
+from ogx_client import OgxClient
+from ogx_client.lib.agents.agent import Agent
+from ogx_client.lib.agents.event_logger import EventLogger
 
 load_dotenv()
 
@@ -13,7 +14,7 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 stream_handler = logging.StreamHandler()
 stream_handler.setLevel(logging.INFO)
-formatter = logging.Formatter('%(message)s')
+formatter = logging.Formatter("%(message)s")
 stream_handler.setFormatter(formatter)
 logger.addHandler(stream_handler)
 
@@ -24,25 +25,21 @@ parser.add_argument("-s", "--session-info-on-exit", help="Prints agent session i
 parser.add_argument("-c", "--prompt-chaining-mode", help="", action="store_true")
 args = parser.parse_args()
 
-model="meta-llama/Llama-3.2-3B-Instruct"
+model = "meta-llama/Llama-3.2-3B-Instruct"
 
 # Connect to an OGX server
 if args.remote:
     base_url = os.getenv("REMOTE_BASE_URL")
 else:
-    base_url="http://localhost:8321"
+    base_url = "http://localhost:8321"
 
-client = OgxClient(
-    base_url=base_url,
-    provider_data={
-        "tavily_search_api_key": os.getenv("TAVILY_SEARCH_API_KEY")
-    })
+client = OgxClient(base_url=base_url, provider_data={"tavily_search_api_key": os.getenv("TAVILY_SEARCH_API_KEY")})
 logger.info(f"Connected to OGX server @ {base_url} \n")
 
 # Get tool info and register tools
 registered_tools = client.tools.list()
 registered_toolgroups = [t.toolgroup_id for t in registered_tools]
-if  "builtin::websearch" not in registered_toolgroups:
+if "builtin::websearch" not in registered_toolgroups:
     client.toolgroups.register(
         toolgroup_id="builtin::websearch",
         provider_id="tavily-search",
@@ -52,18 +49,18 @@ if  "builtin::websearch" not in registered_toolgroups:
 agent = Agent(
     client=client,
     model=model,
-    instructions = """You are a helpful AI assistant, responsible for helping me find and communicate information back to my team.
+    instructions="""You are a helpful AI assistant, responsible for helping me find and communicate information back to my team.
     You have access to a number of tools.
     Whenever a tool is called, be sure return the Response in a friendly and helpful tone.
     When you are asked to search the web you must use a tool.
     When signing off on emails, please be sure to include: - Sent from my ogx agent in the signature
     """,
     tools=["builtin::websearch"],
-    tool_config={"tool_choice":"auto"},
+    tool_config={"tool_choice": "auto"},
     sampling_params={
-        "max_tokens":4096,
+        "max_tokens": 4096,
         "strategy": {"type": "greedy"},
-    }
+    },
 )
 
 session_name = f"Draft_email_with_latest_OCP_version{uuid.uuid4()}"
@@ -73,7 +70,7 @@ if args.prompt_chaining_mode:
     prompts = [
         """Search for the web for the latest Red Hat OpenShift version on the Red Hat website.""",
         """Summarize the latest Red Hat OpenShift version number and any significant features, fixes, or changes that occure in this version.""",
-        """Draft and format an email to convey this information to my team members."""
+        """Draft and format an email to convey this information to my team members.""",
     ]
     for i, prompt in enumerate(prompts):
         turn_response = agent.create_turn(
@@ -92,12 +89,7 @@ if args.prompt_chaining_mode:
 else:
     prompt = """Search for the web for the latest Red Hat OpenShift version on the Red Hat website. Summarize the version number and draft an email to convey this information."""
     turn_response = agent.create_turn(
-        messages=[
-            {
-                "role":"user",
-                "content": prompt
-            }
-        ],
+        messages=[{"role": "user", "content": prompt}],
         session_id=session_id,
         stream=True,
     )

--- a/tests/scripts/agent_with_mcp_ocp_slack.py
+++ b/tests/scripts/agent_with_mcp_ocp_slack.py
@@ -1,12 +1,11 @@
 # Code bellow written following examples here: https://ogx-ai.github.io/docs/building_applications
-from ogx_client import Agent
-from ogx_client.lib.agents.event_logger import EventLogger
-from ogx_client import OgxClient
-from termcolor import cprint
 import argparse
 import logging
 import os
+
 from dotenv import load_dotenv
+from ogx_client import Agent, OgxClient
+from ogx_client.lib.agents.event_logger import EventLogger
 
 load_dotenv()
 
@@ -14,7 +13,7 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 stream_handler = logging.StreamHandler()
 stream_handler.setLevel(logging.INFO)
-formatter = logging.Formatter('%(message)s')
+formatter = logging.Formatter("%(message)s")
 stream_handler.setFormatter(formatter)
 logger.addHandler(stream_handler)
 
@@ -22,7 +21,14 @@ logger.addHandler(stream_handler)
 parser = argparse.ArgumentParser()
 parser.add_argument("-r", "--remote", help="Uses the remote_url", action="store_true")
 parser.add_argument("-s", "--session-info-on-exit", help="Prints agent session info on exit", action="store_true")
-parser.add_argument("-m", "--model", type=str, choices=["llama","granite"], required=True, help="Uses a specific model to run (llama or granite)")
+parser.add_argument(
+    "-m",
+    "--model",
+    type=str,
+    choices=["llama", "granite"],
+    required=True,
+    help="Uses a specific model to run (llama or granite)",
+)
 args = parser.parse_args()
 
 # Connect to an OGX server
@@ -31,9 +37,9 @@ if args.remote:
     slack_mcp_url = os.getenv("REMOTE_SLACK_MCP_URL")
     ocp_mcp_url = os.getenv("REMOTE_OCP_MCP_URL")
 else:
-    base_url="http://localhost:8321"
-    slack_mcp_url="http://host.containers.internal:8000/sse"
-    ocp_mcp_url="http://host.containers.internal:8000/sse"
+    base_url = "http://localhost:8321"
+    slack_mcp_url = "http://host.containers.internal:8000/sse"
+    ocp_mcp_url = "http://host.containers.internal:8000/sse"
 
 client = OgxClient(base_url=base_url)
 logger.info(f"Connected to OGX server @ {base_url} \n")
@@ -49,8 +55,8 @@ if "mcp::slack" not in registered_toolgroups:
     client.toolgroups.register(
         toolgroup_id="mcp::slack",
         provider_id="model-context-protocol",
-        mcp_endpoint={"uri":slack_mcp_url},
-        )
+        mcp_endpoint={"uri": slack_mcp_url},
+    )
 mcp_tools_slack = [t.identifier for t in client.tools.list(toolgroup_id="mcp::slack")]
 
 # check if the openshift mcp server is registered
@@ -59,8 +65,8 @@ if "mcp::openshift" not in registered_toolgroups:
     client.toolgroups.register(
         toolgroup_id="mcp::openshift",
         provider_id="model-context-protocol",
-        mcp_endpoint={"uri":ocp_mcp_url},
-        )
+        mcp_endpoint={"uri": ocp_mcp_url},
+    )
 mcp_tools_ocp = [t.identifier for t in client.tools.list(toolgroup_id="mcp::openshift")]
 
 logger.info(f"""Your Server has access the the following toolgroups:
@@ -68,8 +74,8 @@ logger.info(f"""Your Server has access the the following toolgroups:
 """)
 
 # setting the model names
-llama_model="meta-llama/Llama-3.2-3B-Instruct"
-granite_model="ibm-granite/granite-3.2-8b-instruct"
+llama_model = "meta-llama/Llama-3.2-3B-Instruct"
+granite_model = "ibm-granite/granite-3.2-8b-instruct"
 # system prompts for different models
 llama_prompt = """You are a helpful assistant. You have access to a number of tools.
     Whenever a tool is called, be sure return the Response in a friendly and helpful tone.
@@ -79,38 +85,41 @@ If a tool does not exist in the provided list of tools, notify the user that you
 
 # Create simple agent with tools
 if args.model not in ["llama", "granite"]:
-     print("Unsupported model. Please choose either 'llama' or 'granite'.")
+    print("Unsupported model. Please choose either 'llama' or 'granite'.")
 if args.model == "llama":
     agent = Agent(
         client,
         model=llama_model,
-        instructions = llama_prompt,
+        instructions=llama_prompt,
         tools=["mcp::slack", "mcp::openshift"],
-        tool_config={"tool_choice":"auto"},
-        sampling_params={"max_tokens":4096, "strategy":{"type": "greedy"},}
+        tool_config={"tool_choice": "auto"},
+        sampling_params={
+            "max_tokens": 4096,
+            "strategy": {"type": "greedy"},
+        },
     )
 elif args.model == "granite":
-        agent = Agent(
+    agent = Agent(
         client,
         model=granite_model,
-        instructions = granite_prompt,
+        instructions=granite_prompt,
         tools=["mcp::slack", "mcp::openshift"],
-        tool_config={"tool_choice":"auto"},
-        sampling_params={"max_tokens":4096, "strategy":{"type": "greedy"},}
+        tool_config={"tool_choice": "auto"},
+        sampling_params={
+            "max_tokens": 4096,
+            "strategy": {"type": "greedy"},
+        },
     )
 
-user_prompts = ["""View the logs for pod test-pod in the llama-serve OpenShift namespace. Categorize it as normal or error.""",
-                """Summarize the results with the pod name, category along with a briefly explaination as to why you categorized it as normal or error. Respond with plain text only. Do not wrap your response in additional quotation marks.""",
-                """Send a message with the summarization to the demos channel on Slack."""]
+user_prompts = [
+    """View the logs for pod test-pod in the llama-serve OpenShift namespace. Categorize it as normal or error.""",
+    """Summarize the results with the pod name, category along with a briefly explaination as to why you categorized it as normal or error. Respond with plain text only. Do not wrap your response in additional quotation marks.""",
+    """Send a message with the summarization to the demos channel on Slack.""",
+]
 session_id = agent.create_session(session_name="Slack_OCP_MCP_demo")
 for i, prompt in enumerate(user_prompts):
     turn_response = agent.create_turn(
-        messages=[
-            {
-                "role":"user",
-                "content": prompt
-            }
-        ],
+        messages=[{"role": "user", "content": prompt}],
         session_id=session_id,
         stream=True,
     )


### PR DESCRIPTION
## Summary

- Add **ruff** (lint + format) to pre-commit, replacing manual style enforcement with automated checks
- Add **demo structure validator** (`scripts/validate_demos.py`) — an AST-based checker that verifies demos have required docstring fields, `main(host, port)` signature, and `fire.Fire()` entry point. No server or third-party deps needed.
- Expand pre-commit from 3 hooks to 10: adds check-yaml, check-json, check-merge-conflict, debug-statements, ruff lint, ruff format, and the custom validator
- Fix all existing lint/formatting issues across demo files

Ruff config: Python 3.12, line-length 120, rules `E/W/F/I/UP/B/SIM`.

Part of the contribution standard initiative: #365

## Test plan

- [x] `pre-commit run --all-files` passes
- [x] `python scripts/validate_demos.py` validates all 39 demo files
- [x] `sys.path` usage in `06_openai_compatibility/` reported as warnings (non-blocking), to be fixed in a follow-up
- [x] Multi-entry demos (`08_mcp_tools.py` with `fire.Fire({...})`) handled correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)