### PR TITLE
Standardize all run commands to use uv run python

### DIFF
--- a/demos/00_setup/README.md
+++ b/demos/00_setup/README.md
@@ -48,7 +48,7 @@ Scanning for available providers...
 ## Verify Your Setup
 
 ```bash
-python -m demos.00_setup.01_list_providers localhost 8321
+uv run python -m demos.00_setup.01_list_providers localhost 8321
 ```
 
 This lists all configured providers and available models.

--- a/demos/01_foundations/README.md
+++ b/demos/01_foundations/README.md
@@ -38,7 +38,7 @@ This folder teaches the fundamental building blocks of OGX, including client set
 
 **Run**:
 ```bash
-python -m demos.01_foundations.01_client_setup localhost 8321
+uv run python -m demos.01_foundations.01_client_setup localhost 8321
 ```
 
 ### Demo 2: Chat Completion
@@ -51,10 +51,10 @@ python -m demos.01_foundations.01_client_setup localhost 8321
 **Run**:
 ```bash
 # Basic chat completion
-python -m demos.01_foundations.02_chat_completion localhost 8321 --prompt "Hello"
+uv run python -m demos.01_foundations.02_chat_completion localhost 8321 --prompt "Hello"
 
 # Stream tokens as they arrive
-python -m demos.01_foundations.02_chat_completion localhost 8321 --prompt "Hello" --stream
+uv run python -m demos.01_foundations.02_chat_completion localhost 8321 --prompt "Hello" --stream
 ```
 
 ### Demo 3: System Prompts
@@ -67,10 +67,10 @@ python -m demos.01_foundations.02_chat_completion localhost 8321 --prompt "Hello
 **Run**:
 ```bash
 # Use default system prompt
-python -m demos.01_foundations.03_system_prompts localhost 8321 --prompt "Hello"
+uv run python -m demos.01_foundations.03_system_prompts localhost 8321 --prompt "Hello"
 
 # Override with custom system prompt
-python -m demos.01_foundations.03_system_prompts localhost 8321 --system_prompt "You are concise." --prompt "Hello"
+uv run python -m demos.01_foundations.03_system_prompts localhost 8321 --system_prompt "You are concise." --prompt "Hello"
 ```
 
 ### Demo 4: Vector DB Basics
@@ -83,10 +83,10 @@ python -m demos.01_foundations.03_system_prompts localhost 8321 --system_prompt 
 **Run**:
 ```bash
 # Use default text and query
-python -m demos.01_foundations.04_vector_db_basics localhost 8321
+uv run python -m demos.01_foundations.04_vector_db_basics localhost 8321
 
 # Provide custom text and query
-python -m demos.01_foundations.04_vector_db_basics localhost 8321 --text "OGX unifies AI services." --query "What does OGX do?"
+uv run python -m demos.01_foundations.04_vector_db_basics localhost 8321 --text "OGX unifies AI services." --query "What does OGX do?"
 ```
 
 ### Demo 5: Insert Documents
@@ -99,13 +99,13 @@ python -m demos.01_foundations.04_vector_db_basics localhost 8321 --text "OGX un
 **Run**:
 ```bash
 # Insert documents from URLs
-python -m demos.01_foundations.05_insert_documents localhost 8321
+uv run python -m demos.01_foundations.05_insert_documents localhost 8321
 
 # Insert files from a local directory
-python -m demos.01_foundations.05_insert_documents localhost 8321 --file_dir ./docs
+uv run python -m demos.01_foundations.05_insert_documents localhost 8321 --file_dir ./docs
 
 # Insert into an existing vector store
-python -m demos.01_foundations.05_insert_documents localhost 8321 --vector_store_id <vector-store-id>
+uv run python -m demos.01_foundations.05_insert_documents localhost 8321 --vector_store_id <vector-store-id>
 ```
 
 ### Demo 6: Search Vectors
@@ -117,7 +117,7 @@ python -m demos.01_foundations.05_insert_documents localhost 8321 --vector_store
 
 **Run**:
 ```bash
-python -m demos.01_foundations.06_search_vectors localhost 8321 --query "What does OGX do?"
+uv run python -m demos.01_foundations.06_search_vectors localhost 8321 --query "What does OGX do?"
 ```
 
 ### Demo 7: Tool Runtime API
@@ -129,7 +129,7 @@ python -m demos.01_foundations.06_search_vectors localhost 8321 --query "What do
 
 **Run**:
 ```bash
-python -m demos.01_foundations.07_tool_registration localhost 8321
+uv run python -m demos.01_foundations.07_tool_registration localhost 8321
 ```
 
 ### Demo 8: MCP Tools
@@ -142,7 +142,7 @@ python -m demos.01_foundations.07_tool_registration localhost 8321
 **Run**:
 ```bash
 # Terminal 1: start the MCP server (requires: pip install mcp)
-python -m demos.01_foundations.08_mcp_tools serve
+uv run python -m demos.01_foundations.08_mcp_tools serve
 
 # Terminal 2: register the MCP toolgroup with OGX (Optional)
 ogx-client toolgroups register plus-tools \
@@ -150,5 +150,5 @@ ogx-client toolgroups register plus-tools \
   --mcp-endpoint "http://localhost:8000/sse"
 
 # Terminal 2: invoke the add tool through the runtime
-python -m demos.01_foundations.08_mcp_tools run localhost 8321 --mcp_endpoint http://localhost:8000/sse --tool_name add --a 1 --b 1
+uv run python -m demos.01_foundations.08_mcp_tools run localhost 8321 --mcp_endpoint http://localhost:8000/sse --tool_name add --a 1 --b 1
 ```

--- a/demos/02_responses_basics/README.md
+++ b/demos/02_responses_basics/README.md
@@ -22,7 +22,7 @@ This folder teaches the fundamentals of the Responses API, which provides a high
 
 **Run**:
 ```bash
-python -m demos.02_responses_basics.01_simple_response localhost 8321 --prompt "Hello"
+uv run python -m demos.02_responses_basics.01_simple_response localhost 8321 --prompt "Hello"
 ```
 
 ### Demo 2: Tool Calling
@@ -34,7 +34,7 @@ python -m demos.02_responses_basics.01_simple_response localhost 8321 --prompt "
 
 **Run**:
 ```bash
-python -m demos.02_responses_basics.02_tool_calling localhost 8321 --prompt "Search the web for who was the 42nd president of the United States and answer with the name only."
+uv run python -m demos.02_responses_basics.02_tool_calling localhost 8321 --prompt "Search the web for who was the 42nd president of the United States and answer with the name only."
 ```
 
 ### Demo 3: Conversation Turns
@@ -46,7 +46,7 @@ python -m demos.02_responses_basics.02_tool_calling localhost 8321 --prompt "Sea
 
 **Run**:
 ```bash
-python -m demos.02_responses_basics.03_conversation_turns localhost 8321
+uv run python -m demos.02_responses_basics.03_conversation_turns localhost 8321
 ```
 
 ### Demo 4: Streaming Responses
@@ -58,7 +58,7 @@ python -m demos.02_responses_basics.03_conversation_turns localhost 8321
 
 **Run**:
 ```bash
-python -m demos.02_responses_basics.04_streaming_responses localhost 8321
+uv run python -m demos.02_responses_basics.04_streaming_responses localhost 8321
 ```
 
 ### Demo 5: Response Formats
@@ -70,5 +70,5 @@ python -m demos.02_responses_basics.04_streaming_responses localhost 8321
 
 **Run**:
 ```bash
-python -m demos.02_responses_basics.05_response_formats localhost 8321
+uv run python -m demos.02_responses_basics.05_response_formats localhost 8321
 ```

--- a/demos/03_rag/README.md
+++ b/demos/03_rag/README.md
@@ -21,7 +21,7 @@ This folder teaches Retrieval-Augmented Generation (RAG) techniques using OGX's 
 
 **Run**:
 ```bash
-python -m demos.03_rag.01_simple_rag localhost 8321
+uv run python -m demos.03_rag.01_simple_rag localhost 8321
 ```
 
 ### Demo 2: Multi-Source RAG
@@ -33,7 +33,7 @@ python -m demos.03_rag.01_simple_rag localhost 8321
 
 **Run**:
 ```bash
-python -m demos.03_rag.02_multi_source_rag localhost 8321
+uv run python -m demos.03_rag.02_multi_source_rag localhost 8321
 ```
 
 ### Demo 3: RAG with Metadata
@@ -45,7 +45,7 @@ python -m demos.03_rag.02_multi_source_rag localhost 8321
 
 **Run**:
 ```bash
-python -m demos.03_rag.03_rag_with_metadata localhost 8321 --source doc_a
+uv run python -m demos.03_rag.03_rag_with_metadata localhost 8321 --source doc_a
 ```
 
 ### Demo 4: Chunking Strategies
@@ -57,7 +57,7 @@ python -m demos.03_rag.03_rag_with_metadata localhost 8321 --source doc_a
 
 **Run**:
 ```bash
-python -m demos.03_rag.04_chunking_strategies localhost 8321
+uv run python -m demos.03_rag.04_chunking_strategies localhost 8321
 ```
 
 ### Demo 5: Hybrid Search
@@ -69,5 +69,5 @@ python -m demos.03_rag.04_chunking_strategies localhost 8321
 
 **Run**:
 ```bash
-python -m demos.03_rag.05_hybrid_search localhost 8321
+uv run python -m demos.03_rag.05_hybrid_search localhost 8321
 ```

--- a/demos/04_agents/README.md
+++ b/demos/04_agents/README.md
@@ -23,7 +23,7 @@ This folder teaches how to build conversational agents using the OGX Agent API. 
 
 **Run**:
 ```bash
-python -m demos.04_agents.01_simple_agent_chat --host localhost --port 8321
+uv run python -m demos.04_agents.01_simple_agent_chat --host localhost --port 8321
 ```
 
 ### Demo 2: Multimodal Chat
@@ -36,7 +36,7 @@ python -m demos.04_agents.01_simple_agent_chat --host localhost --port 8321
 **Run**:
 ```bash
 # Note: This demo requires a vision-capable model (e.g., ollama/llama3.2-vision:latest)
-python -m demos.04_agents.02_chat_multimodal --host localhost --port 8321 --model_id ollama/llama3.2-vision:latest
+uv run python -m demos.04_agents.02_chat_multimodal --host localhost --port 8321 --model_id ollama/llama3.2-vision:latest
 ```
 
 ### Demo 3: Chat with Documents
@@ -48,7 +48,7 @@ python -m demos.04_agents.02_chat_multimodal --host localhost --port 8321 --mode
 
 **Run**:
 ```bash
-python -m demos.04_agents.03_chat_with_documents --host localhost --port 8321
+uv run python -m demos.04_agents.03_chat_with_documents --host localhost --port 8321
 ```
 
 ### Demo 4: Agent with Tools
@@ -63,7 +63,7 @@ python -m demos.04_agents.03_chat_with_documents --host localhost --port 8321
 pip install -U yfinance
 ```
 ```bash
-python -m demos.04_agents.04_agent_with_tools --host localhost --port 8321
+uv run python -m demos.04_agents.04_agent_with_tools --host localhost --port 8321
 ```
 
 ### Demo 5: RAG Agent
@@ -75,7 +75,7 @@ python -m demos.04_agents.04_agent_with_tools --host localhost --port 8321
 
 **Run**:
 ```bash
-python -m demos.04_agents.05_rag_agent --host localhost --port 8321
+uv run python -m demos.04_agents.05_rag_agent --host localhost --port 8321
 ```
 
 ### Demo 6: ReACT Agent
@@ -87,7 +87,7 @@ python -m demos.04_agents.05_rag_agent --host localhost --port 8321
 
 **Run**:
 ```bash
-python -m demos.04_agents.06_react_agent --host localhost --port 8321
+uv run python -m demos.04_agents.06_react_agent --host localhost --port 8321
 ```
 
 ### Demo 7: Agent Routing
@@ -99,7 +99,7 @@ python -m demos.04_agents.06_react_agent --host localhost --port 8321
 
 **Run**:
 ```bash
-python -m demos.04_agents.07_agent_routing --host localhost --port 8321
+uv run python -m demos.04_agents.07_agent_routing --host localhost --port 8321
 ```
 
 ## Usage Tips

--- a/demos/06_openai_compatibility/README.md
+++ b/demos/06_openai_compatibility/README.md
@@ -17,94 +17,94 @@ Non-streaming and streaming chat completions using `openai.OpenAI`.
 
 ```bash
 # Non-streaming
-python -m demos.06_openai_compatibility.01_chat_completion localhost 8321
+uv run python -m demos.06_openai_compatibility.01_chat_completion localhost 8321
 
 # Streaming
-python -m demos.06_openai_compatibility.01_chat_completion localhost 8321 --stream
+uv run python -m demos.06_openai_compatibility.01_chat_completion localhost 8321 --stream
 ```
 
 ### 02_tool_calling.py
 Standard OpenAI function-calling flow: define tools, parse `tool_calls`, execute locally, send results back.
 
 ```bash
-python -m demos.06_openai_compatibility.02_tool_calling localhost 8321
+uv run python -m demos.06_openai_compatibility.02_tool_calling localhost 8321
 ```
 
 ### 03_responses_api.py
 Uses `client.responses.create()` from the OpenAI SDK against OGX, with both string and structured message-list inputs.
 
 ```bash
-python -m demos.06_openai_compatibility.03_responses_api localhost 8321
+uv run python -m demos.06_openai_compatibility.03_responses_api localhost 8321
 ```
 
 ### 04_responses_max_output_tokens.py
 Demonstrates `max_output_tokens` to limit response length and inspect `incomplete_details` when output is truncated.
 
 ```bash
-python -m demos.06_openai_compatibility.04_responses_max_output_tokens localhost 8321
+uv run python -m demos.06_openai_compatibility.04_responses_max_output_tokens localhost 8321
 ```
 
 ### 05_responses_top_p.py
 Uses `top_p` (nucleus sampling) to control sampling diversity, comparing low, medium, and high values.
 
 ```bash
-python -m demos.06_openai_compatibility.05_responses_top_p localhost 8321
+uv run python -m demos.06_openai_compatibility.05_responses_top_p localhost 8321
 ```
 
 ### 06_responses_truncation.py
 Shows the `truncation` parameter (`"auto"` vs `"disabled"`) for handling long multi-turn contexts.
 
 ```bash
-python -m demos.06_openai_compatibility.06_responses_truncation localhost 8321
+uv run python -m demos.06_openai_compatibility.06_responses_truncation localhost 8321
 ```
 
 ### 07_responses_streaming.py
 Streaming with the Responses API, including `stream_options` with `include_usage` to get token usage statistics.
 
 ```bash
-python -m demos.06_openai_compatibility.07_responses_streaming localhost 8321
+uv run python -m demos.06_openai_compatibility.07_responses_streaming localhost 8321
 ```
 
 ### 08_responses_parallel_tool_calls.py
 Uses `parallel_tool_calls` to control whether the model issues multiple tool calls in a single turn.
 
 ```bash
-python -m demos.06_openai_compatibility.08_responses_parallel_tool_calls localhost 8321
+uv run python -m demos.06_openai_compatibility.08_responses_parallel_tool_calls localhost 8321
 ```
 
 ### 09_responses_service_tier.py
 Sets the `service_tier` parameter (`"auto"`, `"default"`) to control request routing.
 
 ```bash
-python -m demos.06_openai_compatibility.09_responses_service_tier localhost 8321
+uv run python -m demos.06_openai_compatibility.09_responses_service_tier localhost 8321
 ```
 
 ### 10_responses_logprobs.py
 Requests `top_logprobs` to inspect token-level probability data for model interpretability.
 
 ```bash
-python -m demos.06_openai_compatibility.10_responses_logprobs localhost 8321
+uv run python -m demos.06_openai_compatibility.10_responses_logprobs localhost 8321
 ```
 
 ### 11_responses_reasoning.py
 Uses `reasoning.effort` (`"low"`, `"medium"`, `"high"`) to control how much reasoning the model applies.
 
 ```bash
-python -m demos.06_openai_compatibility.11_responses_reasoning localhost 8321
+uv run python -m demos.06_openai_compatibility.11_responses_reasoning localhost 8321
 ```
 
 ### 12_responses_temperature.py
 Controls output randomness with `temperature`, comparing deterministic (0.0) vs creative (1.5) outputs.
 
 ```bash
-python -m demos.06_openai_compatibility.12_responses_temperature localhost 8321
+uv run python -m demos.06_openai_compatibility.12_responses_temperature localhost 8321
 ```
 
 ### 13_responses_combined.py
 Combines multiple parameters (`max_output_tokens`, `temperature`, `top_p`, `truncation`, `service_tier`, `stream`) in single requests.
 
 ```bash
-python -m demos.06_openai_compatibility.13_responses_combined localhost 8321
+uv run python -m demos.06_openai_compatibility.13_responses_combined localhost 8321
 ```
 
 ## Prerequisites

--- a/demos/README.md
+++ b/demos/README.md
@@ -71,7 +71,7 @@ source .venv/bin/activate
 
 # 7️⃣ Test the connection
 #    - Run the client setup demo to verify server is running
-python -m demos.01_foundations.01_client_setup localhost 8321  # Note: port 8321 for local starter server
+uv run python -m demos.01_foundations.01_client_setup localhost 8321  # Note: port 8321 for local starter server
 ```
 
 ### Troubleshooting
@@ -92,7 +92,7 @@ kill <PID>
 
 **Check which providers and models are available:**
 ```bash
-python -m demos.00_setup.01_list_providers localhost 8321
+uv run python -m demos.00_setup.01_list_providers localhost 8321
 ```
 
 ## Available Demos

--- a/scripts/validate_demos.py
+++ b/scripts/validate_demos.py
@@ -6,10 +6,10 @@ Runs both in pre-commit (on changed files) and in CI (on all demo files).
 
 Usage:
     # Validate specific files (pre-commit passes changed files)
-    python scripts/validate_demos.py demos/01_foundations/01_client_setup.py
+    uv run python scripts/validate_demos.py demos/01_foundations/01_client_setup.py
 
     # Validate all demo files
-    python scripts/validate_demos.py
+    uv run python scripts/validate_demos.py
 """
 
 from __future__ import annotations

--- a/tests/run_demos.py
+++ b/tests/run_demos.py
@@ -5,11 +5,11 @@ Auto-scans demo files, reads # demo-requires: tags to determine which demos
 to skip, and runs the rest with a timeout.
 
 Usage:
-    python tests/run_demos.py localhost 8321
-    python tests/run_demos.py localhost 8321 --timeout 180
-    python tests/run_demos.py localhost 8321 --capabilities vision_model,mcp_server
-    python tests/run_demos.py localhost 8321 --phase 04_agents
-    python tests/run_demos.py localhost 8321 --demo demos/03_rag/01_simple_rag.py
+    uv run python tests/run_demos.py localhost 8321
+    uv run python tests/run_demos.py localhost 8321 --timeout 180
+    uv run python tests/run_demos.py localhost 8321 --capabilities vision_model,mcp_server
+    uv run python tests/run_demos.py localhost 8321 --phase 04_agents
+    uv run python tests/run_demos.py localhost 8321 --demo demos/03_rag/01_simple_rag.py
 """
 
 from __future__ import annotations

--- a/tests/test_all_demos.sh
+++ b/tests/test_all_demos.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # DEPRECATED: Use tests/run_demos.py instead, which auto-scans demos and reads
 # per-demo # demo-requires: tags to decide what to skip.
-#   python tests/run_demos.py localhost 8321
+#   uv run python tests/run_demos.py localhost 8321
 set -uo pipefail
 trap 'echo -e "\n\nInterrupted."; exit 130' INT
 


### PR DESCRIPTION
## Summary

Replace bare `python` with `uv run python` across all READMEs, test scripts, and docstrings to ensure commands consistently use the project virtual environment managed by uv.

- 7 README files updated (all phase READMEs + demos/README.md)
- `tests/run_demos.py` and `scripts/validate_demos.py` docstrings updated
- `tests/test_all_demos.sh` deprecated comment updated

Root `README.md` and `CLAUDE.md` already used `uv run` — no changes needed there.

Part of: #365

## Test plan

- [x] `grep -rn "^python -m demos\." --include="*.md" .` returns empty (no bare python remaining)
- [x] `pre-commit run --all-files` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)