### PR TITLE
Add CONTRIBUTING.md, demo template, and PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+## What
+
+<!-- Which demo(s) are you adding or modifying? -->
+
+## Why
+
+<!-- What OGX feature does this demo showcase? Link to the feature PR/issue if applicable. -->
+
+## Phase
+
+<!-- Which phase directory? e.g., 03_rag -->
+
+## Checklist
+
+- [ ] Demo follows the template structure (docstring, `fire.Fire(main)`, `main(host, port, ...)`)
+- [ ] Uses `resolve_model(client, model_id)` for model selection
+- [ ] Runtime dependencies declared with `# demo-requires:` tags
+- [ ] Phase README updated with new demo entry
+- [ ] Demo runs successfully against a local OGX server
+- [ ] Resources cleaned up in `finally` blocks
+- [ ] `pre-commit run --all-files` passes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,113 @@
+# Contributing to ogx-demos
+
+We welcome demo contributions from OGX feature engineers. When a new feature lands, the feature owner is encouraged to add a corresponding demo to this repository.
+
+For demo structure, naming conventions, and documentation standards, see [DEMOS_STRUCTURE.md](DEMOS_STRUCTURE.md).
+
+## Quick Start: Adding a Demo
+
+1. **Fork and clone** the repository, then create a branch:
+
+   ```bash
+   git checkout -b <your-username>/<short-description> upstream/main
+   ```
+
+2. **Pick the right phase directory** under `demos/`. See [DEMOS_STRUCTURE.md](DEMOS_STRUCTURE.md) for phase descriptions. If your demo doesn't fit an existing phase, open an issue to discuss adding a new one.
+
+3. **Copy the template**:
+
+   ```bash
+   cp demos/_template.py demos/<phase>/NN_your_demo.py
+   ```
+
+   Use a numbered prefix (`NN_`) that places your demo in the correct learning order within the phase. Check existing files in the directory for the next available number.
+
+4. **Implement your demo** following the template. Key patterns:
+   - Docstring with `Demo:`, `Description:`, and `Learning Objectives:` fields.
+   - `main(host, port, ...)` function with `fire.Fire(main)`.
+   - Use `resolve_model(client, model_id)` from `demos.shared.utils` for model selection.
+   - Use `from demos.shared.utils import ...` for shared utilities (not `sys.path` manipulation).
+   - Clean up any resources (vector stores, files) in a `finally` block.
+
+5. **Declare runtime dependencies** with `# demo-requires:` comment tags at the top of the file, before the docstring:
+
+   ```python
+   # demo-requires: TAVILY_SEARCH_API_KEY
+   # demo-requires: vision_model
+   """
+   Demo: My Demo
+   ...
+   """
+   ```
+
+   - `UPPER_CASE` values are treated as environment variable names.
+   - `lower_case` values are capability tags (e.g., `vision_model`, `mcp_server`).
+   - Demos without any `# demo-requires:` tags are assumed to have no special dependencies.
+
+6. **Update the phase README** (`demos/<phase>/README.md`) with an entry for your demo, following the format of existing entries.
+
+7. **Run checks locally**:
+
+   ```bash
+   # Lint and validate
+   pre-commit run --all-files
+
+   # Run your demo against a local server
+   uv run python -m demos.<phase>.<demo_name> localhost 8321
+
+   # Run the test harness (optional, requires a running OGX server)
+   uv run python tests/run_demos.py localhost 8321 --demo demos/<phase>/<demo_name>.py
+   ```
+
+8. **Open a pull request** against `main`.
+
+## Checklist
+
+Before opening your PR, verify:
+
+- [ ] Demo has the standard docstring (`Demo:` / `Description:` / `Learning Objectives:`)
+- [ ] Uses `fire.Fire(main)` with `main(host: str, port: int, ...)` signature
+- [ ] Uses package imports (`from demos.shared.utils import ...`)
+- [ ] Uses `resolve_model(client, model_id)` for model selection (not `os.getenv("OGX_MODEL")`)
+- [ ] Runtime dependencies declared with `# demo-requires:` tags
+- [ ] Resources are cleaned up in `finally` blocks
+- [ ] Phase `README.md` updated with new demo entry
+- [ ] `pre-commit run --all-files` passes
+
+## Branching and Pull Requests
+
+- **Branch naming**: `<username>/<short-description>` (e.g., `jdoe/add-streaming-rag-demo`)
+- **One demo per PR** preferred. Multiple related demos in one PR are acceptable.
+- PRs must pass CI checks before merge.
+
+## Shared Utilities
+
+Common helper functions live in `demos/shared/utils.py`. Use them instead of duplicating logic across demos (e.g., `resolve_model`, `resolve_embedding_model`, `get_embedding_dimension`).
+
+**When to add to shared utilities**: if 3 or more demos would benefit from the same helper function, add it to `demos/shared/utils.py`. Otherwise, keep the logic local to your demo.
+
+## Adding a New Phase
+
+Adding a new top-level phase directory (e.g., `demos/08_new_topic/`) is rare. If you believe one is needed:
+
+1. Open an issue to discuss the scope and placement.
+2. Create the directory with an `__init__.py` and a `README.md` following the format of existing phase READMEs.
+3. Update the root `README.md` and `DEMOS_STRUCTURE.md` to include the new phase.
+
+## Running Demos
+
+All demos are run as Python modules:
+
+```bash
+uv run python -m demos.<phase>.<demo_name> <host> <port> [options]
+```
+
+For example:
+
+```bash
+uv run python -m demos.01_foundations.01_client_setup localhost 8321
+```
+
+## Questions?
+
+Open an issue in the [repository](https://github.com/ogx-ai/ogx-demos/issues).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,9 +40,10 @@ For demo structure, naming conventions, and documentation standards, see [DEMOS_
    """
    ```
 
-   - `UPPER_CASE` values are treated as environment variable names.
+   - `UPPER_CASE` values are treated as environment variable names. The test harness (`tests/run_demos.py`) checks whether these are set before running the demo.
    - `lower_case` values are capability tags (e.g., `vision_model`, `mcp_server`).
    - Demos without any `# demo-requires:` tags are assumed to have no special dependencies.
+   - If your demo requires a new environment variable that isn't in `.env.example`, add it there (commented out, with a description). Users can then uncomment and fill in their own keys in their local `.env` to enable the demo in the test harness.
 
 6. **Update the phase README** (`demos/<phase>/README.md`) with an entry for your demo, following the format of existing entries.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,12 +75,6 @@ Before opening your PR, verify:
 - [ ] Phase `README.md` updated with new demo entry
 - [ ] `pre-commit run --all-files` passes
 
-## Branching and Pull Requests
-
-- **Branch naming**: `<username>/<short-description>` (e.g., `jdoe/add-streaming-rag-demo`)
-- **One demo per PR** preferred. Multiple related demos in one PR are acceptable.
-- PRs must pass CI checks before merge.
-
 ## Shared Utilities
 
 Common helper functions live in `demos/shared/utils.py`. Use them instead of duplicating logic across demos (e.g., `resolve_model`, `resolve_embedding_model`, `get_embedding_dimension`).
@@ -91,9 +85,9 @@ Common helper functions live in `demos/shared/utils.py`. Use them instead of dup
 
 Adding a new top-level phase directory (e.g., `demos/08_new_topic/`) is rare. If you believe one is needed:
 
-1. Open an issue to discuss the scope and placement.
-2. Create the directory with an `__init__.py` and a `README.md` following the format of existing phase READMEs.
-3. Update the root `README.md` and `DEMOS_STRUCTURE.md` to include the new phase.
+1. Create the directory with an `__init__.py` and a `README.md` following the format of existing phase READMEs.
+2. Update the root `README.md` and `DEMOS_STRUCTURE.md` to include the new phase.
+3. Explain the scope and placement in the PR description.
 
 ## Running Demos
 

--- a/demos/_template.py
+++ b/demos/_template.py
@@ -1,0 +1,82 @@
+# demo-requires: EXAMPLE_ENV_VAR
+"""
+Demo: [Name]
+
+Description:
+[What this demo teaches — 1-2 sentences.]
+
+Learning Objectives:
+- [Objective 1]
+- [Objective 2]
+- [Objective 3]
+"""
+
+from __future__ import annotations
+
+import os
+
+import fire
+from ogx_client import OgxClient
+from termcolor import colored
+
+from demos.shared.utils import (
+    can_model_chat,
+    check_model_is_available,
+    resolve_model,
+)
+
+try:
+    from dotenv import load_dotenv
+except Exception:  # pragma: no cover - optional dependency
+    load_dotenv = None
+
+
+def _maybe_load_dotenv() -> None:
+    if load_dotenv is not None:
+        load_dotenv()
+
+
+def main(
+    host: str,
+    port: int,
+    model_id: str | None = None,
+) -> None:
+    _maybe_load_dotenv()
+
+    client = OgxClient(base_url=f"http://{host}:{port}")
+
+    resolved_model = model_id or os.getenv("OGX_CHAT_MODEL") or None
+    if resolved_model is None:
+        resolved_model = resolve_model(client, None)
+        if resolved_model is None:
+            return
+    else:
+        if not check_model_is_available(client, resolved_model):
+            return
+        if not can_model_chat(client, resolved_model):
+            print(
+                colored(
+                    f"Model `{resolved_model}` does not support chat. Choose a chat-capable model.",
+                    "red",
+                )
+            )
+            return
+
+    # --- Your demo logic here ---
+    #
+    # If you create resources (vector stores, files, etc.), clean them up:
+    #
+    # resource = None
+    # try:
+    #     resource = client.vector_stores.create(...)
+    #     # ... demo logic ...
+    # finally:
+    #     if resource is not None:
+    #         try:
+    #             client.vector_stores.delete(vector_store_id=resource.id)
+    #         except Exception as e:
+    #             print(colored(f"Warning: cleanup failed: {e}", "yellow"))
+
+
+if __name__ == "__main__":
+    fire.Fire(main)


### PR DESCRIPTION
## Summary

- **CONTRIBUTING.md**: Quick start guide for adding demos (8-step process), checklist, branching conventions, shared utilities guidelines. Links to DEMOS_STRUCTURE.md for structural details. Covers `# demo-requires:` tags, `resolve_model()` usage, and `uv run` commands.
- **demos/_template.py**: Copyable demo template with all standard patterns — docstring fields, `fire.Fire(main)`, `resolve_model`, dotenv, `# demo-requires:` tag, and resource cleanup.
- **.github/pull_request_template.md**: What/Why/Phase fields with a 7-item checklist matching CONTRIBUTING.md.

Part of: #365

## Test plan

- [x] `pre-commit run --all-files` passes
- [x] `_template.py` passes `validate_demos.py` (underscore prefix is in SKIP_FILES, so it's excluded from validation — as intended)

🤖 Generated with [Claude Code](https://claude.com/claude-code)